### PR TITLE
styled-system 파일 eslint ignore 안되는 버그 수정

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  ignorePatterns: ['.next/', 'node_modules/', 'public', '@types', 'src/styled-system/'],
+  ignorePatterns: ['.next/', 'node_modules/', 'public', '@types', 'src/styled-system'],
   plugins: ['simple-import-sort', 'testing-library'],
   extends: [
     'next/core-web-vitals',

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/styled-system


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
styled-system 을 eslint ignore 해주어야하는데 파일 경로 설정이 제대로 들어가지 않았는지 lint가 적용된채로 git에 올라오고 있었습니다.

## 🎉 변경 사항
- ignorePatterns
- .prettierignore 추가

### 🙏 여기는 꼭 봐주세요!

### 사용 방법

## 🌄 스크린샷

## 📚 참고