### PR TITLE
[Fix] Storybook build error fix

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -10,6 +10,9 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
+    nextjs: {
+      appDirectory: true,
+    },
   },
 };
 

--- a/src/components/Layout/Header.stories.ts
+++ b/src/components/Layout/Header.stories.ts
@@ -9,6 +9,9 @@ const meta = {
   parameters: {
     // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'centered',
+    nextjs: {
+      appDirectory: true,
+    },
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   tags: ['autodocs'],

--- a/src/components/Layout/Header.stories.ts
+++ b/src/components/Layout/Header.stories.ts
@@ -9,9 +9,6 @@ const meta = {
   parameters: {
     // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'centered',
-    nextjs: {
-      appDirectory: true,
-    },
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   tags: ['autodocs'],
@@ -19,6 +16,7 @@ const meta = {
 } satisfies Meta<typeof Header>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
- 크로마틱 빌드 이슈 해결
- storybook build 가 안됨을 확인
- storybook Header Component storybook 실행 버그 수정

## 🎉 변경 사항
`import { useRouter } from 'next/navigation';` 를 이용한 컴포넌트를 스토리북에서 사용하면 발생하는 오류였습니다. 
@준호 가 말한것 처럼 모든 스토리에 넣으면 불편하니 storybook 세팅 중 하나인 `preview.ts` 파일을 수정해서, 모든 스토리에 공통적으로 포함되게 하였어요. 

## 📚 참고
- https://github.com/vercel/next.js/discussions/50068