### PR TITLE
♻️ Input type='normal' 컴포넌트 리팩토링

### DIFF
--- a/src/app/auth/nickname/page.tsx
+++ b/src/app/auth/nickname/page.tsx
@@ -15,10 +15,6 @@ export default function AuthNickNamePage() {
     setNickname(value);
   };
 
-  const onContentCloseIconClick = () => {
-    setNickname('');
-  };
-
   const isSubmitButtonDisabled = !nickname;
 
   const handleSubmit = () => {
@@ -39,12 +35,10 @@ export default function AuthNickNamePage() {
           placeholder="미션명을 입력하세요"
           name="닉네임"
           required
-          iconName="input-close-circle"
-          iconColor="icon.secondary"
           maxLength={20}
           value={nickname}
-          onIconClick={onContentCloseIconClick}
           onChange={handleNickname}
+          description="description"
         />
         <div className={buttonContainerCss}>
           <Button variant={'cta'} size={'medium'} onClick={handleSubmit} disabled={isSubmitButtonDisabled}>

--- a/src/app/mission/new/MissionRegistration.tsx
+++ b/src/app/mission/new/MissionRegistration.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Button from '@/components/Button/Button';
-import DropdownInput from '@/components/Input/DropdownInput';
 import Input from '@/components/Input/Input';
 import { type DropdownValueType } from '@/components/Input/Input.types';
 import { MISSION_CATEGORY_LIST, PUBLIC_SETTING_LIST } from '@/constants/mission';
@@ -58,7 +57,7 @@ export default function MissionRegistration() {
       />
 
       {/* 카테고리 */}
-      <DropdownInput
+      <Input
         variant="drop-down"
         title="카테고리"
         required
@@ -69,7 +68,7 @@ export default function MissionRegistration() {
       />
 
       {/* 공개설정 */}
-      <DropdownInput
+      <Input
         variant="drop-down"
         title="공개설정"
         list={PUBLIC_SETTING_LIST}

--- a/src/app/mission/new/MissionRegistration.tsx
+++ b/src/app/mission/new/MissionRegistration.tsx
@@ -25,17 +25,17 @@ export default function MissionRegistration() {
   const handleMissionTitleInput = (value: string) => {
     setMissionTitleInput(value);
   };
-  const onTitleCloseIconClick = () => {
-    setMissionTitleInput('');
-  };
+  // const onTitleCloseIconClick = () => {
+  //   setMissionTitleInput('');
+  // };
 
   // 미션 내용
   const handleMissionContentInput = (value: string) => {
     setMissionContentInput(value);
   };
-  const onContentCloseIconClick = () => {
-    setMissionContentInput('');
-  };
+  // const onContentCloseIconClick = () => {
+  //   setMissionContentInput('');
+  // };
 
   const handleSubmit = () => {
     if (!missionCategory) return;
@@ -49,27 +49,24 @@ export default function MissionRegistration() {
         placeholder="미션명을 입력하세요"
         name="미션명"
         required
-        iconName="input-close-circle"
-        iconColor="icon.secondary"
         maxLength={20}
         value={missionTitleInput}
-        onIconClick={onTitleCloseIconClick}
         onChange={handleMissionTitleInput}
+        description="디스크립션 영역입니다"
       />
       <Input
         type="text"
         placeholder="미션 내용을 입력"
         name="미션내용"
-        iconName="input-close-circle"
-        iconColor="icon.secondary"
         maxLength={30}
         value={missionContentInput}
-        onIconClick={onContentCloseIconClick}
         onChange={handleMissionContentInput}
+        description="디스크립션 영역입니다"
       />
 
       {/* 카테고리 */}
       <DropdownInput
+        variant="drop-down"
         title="카테고리"
         required
         list={MISSION_CATEGORY_LIST}
@@ -80,6 +77,7 @@ export default function MissionRegistration() {
 
       {/* 공개설정 */}
       <DropdownInput
+        variant="drop-down"
         title="공개설정"
         list={PUBLIC_SETTING_LIST}
         selected={missionPublicSetting}

--- a/src/app/mission/new/MissionRegistration.tsx
+++ b/src/app/mission/new/MissionRegistration.tsx
@@ -25,17 +25,10 @@ export default function MissionRegistration() {
   const handleMissionTitleInput = (value: string) => {
     setMissionTitleInput(value);
   };
-  // const onTitleCloseIconClick = () => {
-  //   setMissionTitleInput('');
-  // };
-
   // 미션 내용
   const handleMissionContentInput = (value: string) => {
     setMissionContentInput(value);
   };
-  // const onContentCloseIconClick = () => {
-  //   setMissionContentInput('');
-  // };
 
   const handleSubmit = () => {
     if (!missionCategory) return;

--- a/src/components/Input/Input.stories.ts
+++ b/src/components/Input/Input.stories.ts
@@ -1,21 +1,31 @@
-import DropdownInput from '@/components/Input/DropdownInput';
+import Input from '@/components/Input/Input';
 import { type Meta, type StoryObj } from '@storybook/react';
 
 const meta = {
   title: 'Component/Input',
-  component: DropdownInput,
+  component: Input,
   parameters: {
     layout: 'centered',
   },
   tags: ['autodocs'],
-} satisfies Meta<typeof DropdownInput>;
+} satisfies Meta<typeof Input>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Primary: Story = {
+export const NormalInput: Story = {
   args: {
+    variant: 'normal',
+    name: '미션명',
+    placeholder: '미션명을 입력하세요',
+    value: '운동',
+    description: '디스크립션 영역입니다',
+  },
+};
+export const Dropdown: Story = {
+  args: {
+    variant: 'drop-down',
     title: '카테고리',
     required: true,
     list: [

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,127 +1,15 @@
-'use client';
-import { type InputHTMLAttributes } from 'react';
-import { useState } from 'react';
-import { css } from '@/styled-system/css';
+import DropdownInput from '@/components/Input/DropdownInput';
+import { type InputType } from '@/components/Input/Input.types';
+import NormalInput from '@/components/Input/NormalInput';
 
-import Icon from '../Icon';
-import { type IconComponentMap, type IconComponentProps } from '../Icon';
-
-interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
-  iconName?: keyof typeof IconComponentMap; // iconName prop 수정
-  iconColor?: IconComponentProps['color']; // 추가: iconColor prop
-  value?: string;
-  onChange?: (value: string) => void;
-  onIconClick?: () => void;
+function Input(props: InputType) {
+  switch (props.variant) {
+    case 'drop-down':
+      return <DropdownInput {...props} />;
+    case 'normal':
+    default:
+      return <NormalInput {...props} />;
+  }
 }
 
-export default function Input({ iconName, value, onChange, iconColor, onIconClick, ...inputProps }: InputProps) {
-  const { required, name, maxLength } = inputProps;
-  const [inputValue, setInputValue] = useState(value ? String(value) : '');
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const _value = e.target.value;
-
-    // input의 기본 속성인 maxLength만으로는 한글 대응이 불가능.
-    if (inputProps.maxLength && _value.length > inputProps.maxLength) {
-      return;
-    }
-
-    setInputValue(_value);
-    if (onChange) {
-      onChange(_value);
-    }
-  };
-
-  //Icon이 클릭되면 onIconClick props로 넘겨받은 함수 호출
-  const onIconClickHandler = () => {
-    setInputValue(''); // 클릭되면 input value를 빈 문자열로 초기화
-    onChange && onChange('');
-
-    if (onIconClick) {
-      onIconClick();
-    }
-  };
-
-  return (
-    <section>
-      <p className={subTitleCss}>
-        {/* 인풋타이틀 */}
-        {name}
-        {required && <span className={asterisk}> *</span>}
-      </p>
-
-      <div className={inputWrapperCss}>
-        <input
-          className={inputCss}
-          required
-          autoComplete="off"
-          value={inputValue}
-          onChange={handleChange}
-          {...inputProps}
-        />
-        {inputValue.length > 0 && iconName && (
-          <Icon name={iconName} color={iconColor} className={iconCss} onClick={onIconClickHandler} />
-        )}
-      </div>
-
-      <div className={descriptionCss}>
-        {/* 처음엔 안보이다가 input의 길이가 너무 길면 빨간색으로 표시 */}
-        <span className={descriptionTextCss}>디스크립션 영역입니다</span>
-
-        {maxLength && (
-          <span className={inputLengthCss}>
-            {inputValue.length}/{maxLength}
-          </span>
-        )}
-      </div>
-    </section>
-  );
-}
-const descriptionCss = css({
-  display: 'flex',
-  justifyContent: 'space-between',
-  marginTop: '12px',
-});
-
-const inputWrapperCss = css({
-  display: 'flex',
-  justifyContent: 'space-between',
-  width: '100%',
-  borderBottomWidth: '1px',
-  padding: '14px 4px',
-  backgroundColor: 'bg.surface1',
-  borderColor: 'border.default',
-  _focusWithin: { outline: 'none', borderColor: 'purple.purple500' },
-  boxSizing: 'border-box',
-});
-
-const subTitleCss = css({
-  textStyle: 'body4',
-  color: 'text.primary',
-});
-const asterisk = css({
-  color: 'red.red500',
-  fontWeight: 'bold',
-});
-const inputCss = css({
-  width: '375px',
-  height: '22px',
-  textStyle: 'subtitle3',
-  color: 'text.secondary',
-  backgroundColor: 'bg.surface1',
-  _focus: { outline: 'none', borderColor: 'purple.purple500' },
-  _placeholder: { color: 'gray.gray300' },
-});
-
-const inputLengthCss = css({
-  textStyle: 'body3',
-  color: 'text.secondary',
-});
-
-const descriptionTextCss = css({
-  color: 'bg.surface1',
-});
-
-const iconCss = css({
-  cursor: 'pointer',
-});
+export default Input;

--- a/src/components/Input/Input.types.ts
+++ b/src/components/Input/Input.types.ts
@@ -1,4 +1,16 @@
-interface InputBaseType {}
+import { type InputHTMLAttributes } from 'react';
+
+interface InputBaseType {
+  variant?: 'normal' | 'drop-down';
+}
+
+export interface NormalInputType extends InputBaseType, Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
+  variant?: 'normal';
+  value: string;
+  onChange?: (value: string) => void;
+
+  description: string;
+}
 
 export interface DropdownValueType {
   imgUrl?: string;
@@ -7,11 +19,13 @@ export interface DropdownValueType {
 }
 
 export interface DropDownInputType extends InputBaseType {
+  variant: 'drop-down';
   selected: DropdownValueType | null;
   onSelect: (value: DropdownValueType) => void;
   list: DropdownValueType[];
   placeholder?: string;
-
   title: string;
   required?: boolean;
 }
+
+export type InputType = DropDownInputType | NormalInputType;

--- a/src/components/Input/NormalInput.tsx
+++ b/src/components/Input/NormalInput.tsx
@@ -1,43 +1,34 @@
-'use client';
-import { useState } from 'react';
 import { type NormalInputType } from '@/components/Input/Input.types';
 import { css } from '@/styled-system/css';
 
 import Icon from '../Icon';
 
 export default function NormalInput({ value, onChange, ...props }: NormalInputType) {
-  const [inputValue, setInputValue] = useState(value ? String(value) : '');
-
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const _value = e.target.value;
+    const inputValue = e.target.value;
 
     // input의 기본 속성인 maxLength만으로는 한글 대응이 불가능.
-    if (props.maxLength && _value.length > props.maxLength) {
+    if (props.maxLength && inputValue.length > props.maxLength) {
       return;
     }
 
-    setInputValue(_value);
-    if (onChange) {
-      onChange(_value);
-    }
+    onChange?.(inputValue);
   };
 
   const onDelete = () => {
-    setInputValue(''); // 클릭되면 input value를 빈 문자열로 초기화
-    onChange && onChange('');
+    onChange?.('');
   };
 
   return (
     <section>
       <p className={subTitleCss}>
-        {/* 인풋타이틀 */}
         {props.name}
-        {props.required && <span className={asterisk}> *</span>}
+        {props.required && <span className={asterisk}>*</span>}
       </p>
 
       <div className={inputWrapperCss}>
-        <input className={inputCss} required autoComplete="off" value={inputValue} onChange={handleChange} {...props} />
-        {inputValue.length > 0 && (
+        <input className={inputCss} required autoComplete="off" value={value} onChange={handleChange} {...props} />
+        {value.length > 0 && (
           <Icon name={'close-circle'} color={'icon.tertiary'} className={iconCss} onClick={onDelete} />
         )}
       </div>
@@ -48,13 +39,14 @@ export default function NormalInput({ value, onChange, ...props }: NormalInputTy
 
         {props.maxLength && (
           <span className={inputLengthCss}>
-            {inputValue.length}/{props.maxLength}
+            {value.length}/{props.maxLength}
           </span>
         )}
       </div>
     </section>
   );
 }
+
 const descriptionCss = css({
   display: 'flex',
   justifyContent: 'space-between',
@@ -67,6 +59,7 @@ const inputWrapperCss = css({
   width: '100%',
   borderBottomWidth: '1px',
   padding: '14px 4px',
+  height: '50px',
   backgroundColor: 'bg.surface1',
   borderColor: 'border.default',
   _focusWithin: { outline: 'none', borderColor: 'purple.purple500' },
@@ -77,10 +70,13 @@ const subTitleCss = css({
   textStyle: 'body4',
   color: 'text.primary',
 });
+
 const asterisk = css({
   color: 'red.red500',
   fontWeight: 'bold',
+  marginLeft: '2px',
 });
+
 const inputCss = css({
   width: '375px',
   height: '22px',

--- a/src/components/Input/NormalInput.tsx
+++ b/src/components/Input/NormalInput.tsx
@@ -1,0 +1,105 @@
+'use client';
+import { useState } from 'react';
+import { type NormalInputType } from '@/components/Input/Input.types';
+import { css } from '@/styled-system/css';
+
+import Icon from '../Icon';
+
+export default function NormalInput({ value, onChange, ...props }: NormalInputType) {
+  const [inputValue, setInputValue] = useState(value ? String(value) : '');
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const _value = e.target.value;
+
+    // input의 기본 속성인 maxLength만으로는 한글 대응이 불가능.
+    if (props.maxLength && _value.length > props.maxLength) {
+      return;
+    }
+
+    setInputValue(_value);
+    if (onChange) {
+      onChange(_value);
+    }
+  };
+
+  const onDelete = () => {
+    setInputValue(''); // 클릭되면 input value를 빈 문자열로 초기화
+    onChange && onChange('');
+  };
+
+  return (
+    <section>
+      <p className={subTitleCss}>
+        {/* 인풋타이틀 */}
+        {props.name}
+        {props.required && <span className={asterisk}> *</span>}
+      </p>
+
+      <div className={inputWrapperCss}>
+        <input className={inputCss} required autoComplete="off" value={inputValue} onChange={handleChange} {...props} />
+        {inputValue.length > 0 && (
+          <Icon name={'close-circle'} color={'icon.tertiary'} className={iconCss} onClick={onDelete} />
+        )}
+      </div>
+
+      <div className={descriptionCss}>
+        {/* 처음엔 안보이다가 input의 길이가 너무 길면 빨간색으로 표시 */}
+        {props.description && <span className={descriptionTextCss}>{props.description}</span>}
+
+        {props.maxLength && (
+          <span className={inputLengthCss}>
+            {inputValue.length}/{props.maxLength}
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}
+const descriptionCss = css({
+  display: 'flex',
+  justifyContent: 'space-between',
+  marginTop: '12px',
+});
+
+const inputWrapperCss = css({
+  display: 'flex',
+  justifyContent: 'space-between',
+  width: '100%',
+  borderBottomWidth: '1px',
+  padding: '14px 4px',
+  backgroundColor: 'bg.surface1',
+  borderColor: 'border.default',
+  _focusWithin: { outline: 'none', borderColor: 'purple.purple500' },
+  boxSizing: 'border-box',
+});
+
+const subTitleCss = css({
+  textStyle: 'body4',
+  color: 'text.primary',
+});
+const asterisk = css({
+  color: 'red.red500',
+  fontWeight: 'bold',
+});
+const inputCss = css({
+  width: '375px',
+  height: '22px',
+  textStyle: 'subtitle3',
+  color: 'text.secondary',
+  backgroundColor: 'bg.surface1',
+  _focus: { outline: 'none', borderColor: 'purple.purple500' },
+  _placeholder: { color: 'gray.gray300' },
+});
+
+const inputLengthCss = css({
+  textStyle: 'body3',
+  color: 'text.secondary',
+});
+
+const descriptionTextCss = css({
+  color: 'bg.surface1',
+});
+
+const iconCss = css({
+  cursor: 'pointer',
+});


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
디자인 시스템 이전에 @JUNOSHON 이 만들어준 `Input` 컴포넌트를 현재 디자인 시스템에 맡게 `vairant`를 통해 분기할 수 있도록 하였어요. 

close #218 
## 🎉 변경 사항
- `Input` 파일에 있던 내용이 `NormalInput` 파일로 이동되었어요. 
- 기존에 있던 `icon` props는 우측 아이콘이 고정되어있음에 따라 제거하였어요. 
- 
### 🙏 여기는 꼭 봐주세요!
- 기존에 Input 내부에서 `useState`를 통해 inputValue를 관리하고 있었는데, state로 관리하지 않아도 필요한 기능을 구현할 수 있어 제거하였습니다 . (+ 상단의 'use client'도 삭제하였어요)

## 🌄 스크린샷
<img width="476" alt="스크린샷 2023-12-30 오후 8 41 01" src="https://github.com/depromeet/10mm-client-web/assets/49177223/ec063d30-4fec-4190-9e16-dfd1920b9d14">

