### PR TITLE
🎨 홈탭 디자인 가이드 수정 적용

### DIFF
--- a/src/app/home/AppBar.tsx
+++ b/src/app/home/AppBar.tsx
@@ -5,7 +5,7 @@ import { flex } from '@/styled-system/patterns';
 
 function AppBar() {
   return (
-    <div>
+    <>
       <header className={headerCss}>
         <div className={logoWrapperCss}>
           <Image src={'/assets/10mm-logo.svg'} alt="10MM" width={68} height={20} />
@@ -14,7 +14,8 @@ function AppBar() {
           <Icon name="alarm" />
         </div>
       </header>
-    </div>
+      <div className={blankCss} />
+    </>
   );
 }
 
@@ -25,8 +26,16 @@ const headerCss = flex({
   alignItems: 'center',
   padding: '0 8px',
   justifyContent: 'space-between',
-  //   backgroundColor: 'bg.surface2',
+  backgroundColor: 'bg.surface2',
+
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  margin: '0 auto',
 });
+
+const blankCss = css({ height: '44px' });
 
 const logoWrapperCss = css({
   padding: '12px 6px',

--- a/src/app/home/MissionList.tsx
+++ b/src/app/home/MissionList.tsx
@@ -33,7 +33,7 @@ function MissionList() {
 export default MissionList;
 
 const containerCss = css({
-  padding: '0 16px',
+  padding: '0 16px 30px',
 });
 
 const headingCss = flex({
@@ -64,6 +64,54 @@ const DUMMY_MISSION_LIST = [
     category:
       '글쓰기일이삼사오육칠팔구십일이삼사오육칠팔구십일일이삼사오육칠팔구십일이삼사오육칠팔구십일일이삼사오육칠팔구십일이삼사오육칠팔구십일',
     missionTitle: '포트폴리오 레퍼런스 수집하기',
+    status: 'COMPLETED',
+  },
+  {
+    imageUrl: '/images/category/exercise.png',
+    category: '운동',
+    missionTitle: '스쿼트 해서 튼튼해지자!',
+    status: 'COMPLETED',
+  },
+  {
+    imageUrl: '/images/category/exercise.png',
+    category: '운동',
+    missionTitle: '스쿼트 해서 튼튼해지자!',
+    status: 'COMPLETED',
+  },
+  {
+    imageUrl: '/images/category/exercise.png',
+    category: '운동',
+    missionTitle: '스쿼트 해서 튼튼해지자!',
+    status: 'COMPLETED',
+  },
+  {
+    imageUrl: '/images/category/exercise.png',
+    category: '운동',
+    missionTitle: '스쿼트 해서 튼튼해지자!',
+    status: 'COMPLETED',
+  },
+  {
+    imageUrl: '/images/category/exercise.png',
+    category: '운동',
+    missionTitle: '스쿼트 해서 튼튼해지자!',
+    status: 'COMPLETED',
+  },
+  {
+    imageUrl: '/images/category/exercise.png',
+    category: '운동',
+    missionTitle: '스쿼트 해서 튼튼해지자!',
+    status: 'COMPLETED',
+  },
+  {
+    imageUrl: '/images/category/exercise.png',
+    category: '운동',
+    missionTitle: '스쿼트 해서 튼튼해지자!',
+    status: 'COMPLETED',
+  },
+  {
+    imageUrl: '/images/category/exercise.png',
+    category: '운동',
+    missionTitle: '스쿼트 해서 튼튼해지자!',
     status: 'COMPLETED',
   },
   {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,7 +44,7 @@ const containerCss = {
   maxWidth: '475px',
   margin: '0 auto',
   minHeight: '100vh',
-  backgroundColor: 'bg.surface1',
+  backgroundColor: 'bg.surface2',
 };
 
 const bodyCss = {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,4 +17,5 @@ export default function Home() {
 
 const mainCss = css({
   minHeight: '100vh',
+  paddingBottom: '113px', // 64(app bar bottom) + 15(gap) + 34(indicator)
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import AppBar from '@/app/home/AppBar';
 import MissionList from '@/app/home/MissionList';
 import ProfileList from '@/app/home/ProfileList';
 import AppBarBottom from '@/components/AppBarBottom/AppBarBottom';
+import BottomDim from '@/components/BottomDim/BottomDim';
 import { css } from '@styled-system/css';
 
 export default function Home() {
@@ -11,6 +12,7 @@ export default function Home() {
       <ProfileList />
       <MissionList />
       <AppBarBottom />
+      <BottomDim />
     </main>
   );
 }

--- a/src/components/BottomDim/BottomDim.tsx
+++ b/src/components/BottomDim/BottomDim.tsx
@@ -1,0 +1,21 @@
+import { css } from '@/styled-system/css';
+
+function BottomDim() {
+  return <article className={containerCss}></article>;
+}
+
+export default BottomDim;
+
+const containerCss = css({
+  width: '100vw',
+  height: '200px',
+  maxWidth: '475px',
+  margin: '0 auto',
+  position: 'fixed',
+  left: 0,
+  right: 0,
+  bottom: 0,
+
+  background:
+    'linear-gradient(180deg, rgba(24, 24, 29, 0.00) 0%, rgba(24, 24, 29, 0.09) 7.58%, rgba(24, 24, 29, 0.59) 34.59%, rgba(24, 24, 29, 0.69) 41.18%, rgba(24, 24, 29, 0.83) 51.39%, #18181D 63.25%)',
+});


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
closed #232 
<!-- 관련 이슈를 적어주세요 -->
<!-- closed #1-->

## 🎉 변경 사항
- 홈탭 메인 scroll guide 추가
- 홈탭 메인에 bottom-dim 추가
- 홈탭 상단 app bar position 상단에 배치
### 🙏 여기는 꼭 봐주세요!
-  bottom-dim의 경우 다른 페이지에서도 사용하기 때문에 `components` 폴더에 구현
### 사용 방법

## 🌄 스크린샷
![스크린샷 2023-12-31 오후 8 51 31](https://github.com/depromeet/10mm-client-web/assets/49177223/c323c20f-9813-42ac-9308-5ce8d92f4c90)

## 📚 참고
