### PR TITLE
[Design] Header 컴포넌트 text button 인경우 피그마와 다르게 구현된 부분 수정

### DIFF
--- a/src/components/Header/HeaderBase.tsx
+++ b/src/components/Header/HeaderBase.tsx
@@ -43,7 +43,7 @@ const positionCss = {
 
 const wrapperCss = flex({
   ...positionCss,
-  padding: '12px',
+  padding: '12px 0 12px 12px',
   background: 'bg.surface1',
   margin: '0 auto',
   left: 0,

--- a/src/components/Header/IconHeader.tsx
+++ b/src/components/Header/IconHeader.tsx
@@ -1,12 +1,17 @@
 import { type IconHeaderType } from '@/components/Header/Header.types';
 import HeaderBase from '@/components/Header/HeaderBase';
 import Icon from '@/components/Icon';
+import { css } from '@styled-system/css';
 
 function IconHeader({ iconName = 'close', ...props }: IconHeaderType) {
   return (
     <HeaderBase
       rightElement={
-        <div>
+        <div
+          className={css({
+            padding: '12px',
+          })}
+        >
           <Icon name={iconName} width={20} height={20} />
         </div>
       }

--- a/src/components/Header/IconHeader.tsx
+++ b/src/components/Header/IconHeader.tsx
@@ -7,11 +7,7 @@ function IconHeader({ iconName = 'close', ...props }: IconHeaderType) {
   return (
     <HeaderBase
       rightElement={
-        <div
-          className={css({
-            padding: '12px',
-          })}
-        >
+        <div className={iconWrapperCss}>
           <Icon name={iconName} width={20} height={20} />
         </div>
       }
@@ -21,3 +17,7 @@ function IconHeader({ iconName = 'close', ...props }: IconHeaderType) {
 }
 
 export default IconHeader;
+
+const iconWrapperCss = css({
+  padding: '12px',
+});


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
- Header 컴포넌트 text button 인경우 피그마와 다르게 구현된 부분 수정
오른쪽 element의 padding값이 달라서 수정해 주었어요

- 피그마
![스크린샷 2024-01-02 오후 11 56 16](https://github.com/depromeet/10mm-client-web/assets/68339352/5ae03ce1-bfd3-41a2-b712-d81321ad5dab)

- 구현되어있던 Header 컴포넌트
![스크린샷 2024-01-02 오후 11 56 25](https://github.com/depromeet/10mm-client-web/assets/68339352/0a54a9a5-a6df-4882-b03b-19e7ff078b48)

## 🎉 변경 사항
오른쪽 element의 padding값이 달라서 수정 버튼인 경우 header wrapper 의 padding 안넣고 버튼 컴포넌트의 padding 만으로 간격 조절

### 🙏 여기는 꼭 봐주세요!

### 사용 방법

## 🌄 스크린샷

수정본
<img width="441" alt="스크린샷 2024-01-02 오후 11 39 17" src="https://github.com/depromeet/10mm-client-web/assets/68339352/fbadbceb-422f-4b89-b0c3-01ce4da22a9e">

## 📚 참고
https://www.figma.com/file/waOSgkTYJKQdMHXnGPlOum/%5BDEV%5D-Design-Guide?node-id=591%3A3866&mode=dev