### PR TITLE
🎨 badge 새로운 타입 추가

### DIFF
--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -49,3 +49,11 @@ export const Red: Story = {
     children: 'badge',
   },
 };
+
+export const GrayContain: Story = {
+  args: {
+    color: 'gray',
+    variant: 'solid',
+    children: 'badge',
+  },
+};

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -7,7 +7,6 @@ const badgeStyle = cva({
     height: '23px',
     padding: '3px 10px 3px 10px',
     borderRadius: '15px',
-    border: '0.5px solid',
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'center',
@@ -32,6 +31,25 @@ const badgeStyle = cva({
         backgroundColor: 'red.red000',
       },
     },
+    variant: {
+      solid: {},
+      line: {
+        border: '0.5px solid',
+      },
+    },
+  },
+  compoundVariants: [
+    {
+      color: 'gray',
+      variant: 'solid',
+      css: {
+        backgroundColor: 'gray.gray300',
+        color: 'purple.purple800',
+      },
+    },
+  ],
+  defaultVariants: {
+    variant: 'line',
   },
 });
 


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
closed #255 
<!-- 관련 이슈를 적어주세요 -->
<!-- closed #1-->

## 🎉 변경 사항
- Badge 컴포넌트에 `variant` 라는 props를 추가하였어요. 
- 그리고 기존 Badge에 호환되게 `line`이라는 variant를 기본값으로 설정하였습니다. 
- color + variant='solid'의 경우에는 color 마다 조합을 해주어야해서, `compoundVariants`를 사용하였습니다. 