### PR TITLE
[Feat] Input variant normal-button 추가

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -79,7 +79,7 @@ const buttonStyle = cva({
           backgroundColor: 'gray.gray100',
         },
         '&:disabled': {
-          filter: 'brightness(0.4)',
+          filter: 'brightness(0.9)',
           backgroundColor: 'gray.gray100',
           color: 'text.placeholder',
         },

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -2,10 +2,14 @@ import DropdownInput from '@/components/Input/DropdownInput';
 import { type InputType } from '@/components/Input/Input.types';
 import NormalInput from '@/components/Input/NormalInput';
 
+import NormalButtonInput from './NormalButtonInput';
+
 function Input<Value extends string = string>(props: InputType<Value>) {
   switch (props.variant) {
     case 'drop-down':
       return <DropdownInput {...props} />;
+    case 'normal-button':
+      return <NormalButtonInput {...props} />;
     case 'normal':
     default:
       return <NormalInput {...props} />;

--- a/src/components/Input/Input.types.ts
+++ b/src/components/Input/Input.types.ts
@@ -27,6 +27,7 @@ export interface NormalButtonInputTypes extends InputBaseType, Omit<InputHTMLAtt
   description?: string;
   errorMsg?: string;
   positiveMsg?: string;
+  required?: boolean;
 }
 
 export interface DropDownInputType<T extends string> extends InputBaseType {

--- a/src/components/Input/Input.types.ts
+++ b/src/components/Input/Input.types.ts
@@ -28,6 +28,7 @@ export interface NormalButtonInputTypes extends InputBaseType, Omit<InputHTMLAtt
   errorMsg?: string;
   positiveMsg?: string;
   required?: boolean;
+  text?: string;
 }
 
 export interface DropDownInputType<T extends string> extends InputBaseType {

--- a/src/components/Input/Input.types.ts
+++ b/src/components/Input/Input.types.ts
@@ -26,7 +26,7 @@ export interface NormalButtonInputTypes extends InputBaseType, Omit<InputHTMLAtt
 
   description?: string;
   errorMsg?: string;
-  positiveMsg?: string;
+  validMsg?: string;
   required?: boolean;
   text?: string;
 }

--- a/src/components/Input/Input.types.ts
+++ b/src/components/Input/Input.types.ts
@@ -28,7 +28,7 @@ export interface NormalButtonInputTypes extends InputBaseType, Omit<InputHTMLAtt
   errorMsg?: string;
   validMsg?: string;
   required?: boolean;
-  text: string;
+  buttonText: string;
 }
 
 export interface DropDownInputType<T extends string> extends InputBaseType {

--- a/src/components/Input/Input.types.ts
+++ b/src/components/Input/Input.types.ts
@@ -1,7 +1,7 @@
 import { type InputHTMLAttributes } from 'react';
 
 interface InputBaseType {
-  variant?: 'normal' | 'drop-down';
+  variant?: 'normal' | 'drop-down' | 'normal-button';
 }
 
 export interface NormalInputType extends InputBaseType, Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
@@ -19,6 +19,16 @@ export interface DropdownValueType<Value = string> {
   value: Value;
 }
 
+export interface NormalButtonInputTypes extends InputBaseType, Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
+  variant: 'normal-button';
+  value: string;
+  onChange?: (value: string) => void;
+
+  description?: string;
+  errorMsg?: string;
+  positiveMsg?: string;
+}
+
 export interface DropDownInputType<T extends string> extends InputBaseType {
   variant: 'drop-down';
   selected: DropdownValueType<T> | null;
@@ -29,4 +39,4 @@ export interface DropDownInputType<T extends string> extends InputBaseType {
   required?: boolean;
 }
 
-export type InputType<V extends string> = DropDownInputType<V> | NormalInputType;
+export type InputType<V extends string> = DropDownInputType<V> | NormalInputType | NormalButtonInputTypes;

--- a/src/components/Input/Input.types.ts
+++ b/src/components/Input/Input.types.ts
@@ -28,7 +28,7 @@ export interface NormalButtonInputTypes extends InputBaseType, Omit<InputHTMLAtt
   errorMsg?: string;
   validMsg?: string;
   required?: boolean;
-  text?: string;
+  text: string;
 }
 
 export interface DropDownInputType<T extends string> extends InputBaseType {

--- a/src/components/Input/NormalButtonInput.tsx
+++ b/src/components/Input/NormalButtonInput.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useState } from 'react';
+import { type NormalButtonInputTypes } from '@/components/Input/Input.types';
+import { css } from '@/styled-system/css';
+
+import Button from '../Button/Button';
+
+export default function NormalButtonInput({
+  value,
+  onChange,
+  errorMsg,
+  positiveMsg,
+  ...props
+}: NormalButtonInputTypes) {
+  const [isFocused, setIsFocused] = useState(false);
+
+  const statusColor = errorMsg ? 'red.red500' : 'text.tertiary';
+  //닉네임 사용 가능시 디스크립션에 보여줄 positiveColor
+  // const positiveColor = positiveMsg ? 'blue.blue500' : 'text.tertiary';
+
+  //중복확인 버튼이 사용 가능할지에 대한 상태. 네이밍 논의 필요.
+  const [doubleCheckabled, setDoubleCheckAbled] = useState(false);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = e.target.value;
+
+    // input의 기본 속성인 maxLength만으로는 한글 대응이 불가능.
+    if (props.maxLength && inputValue.length > props.maxLength) {
+      return;
+    }
+
+    onChange?.(inputValue);
+    //
+    setDoubleCheckAbled(inputValue.length === 0);
+  };
+
+  const onDoubleCheck = () => {
+    //TODO: 중복확인 로직
+    alert('중복확인 로직 추가');
+  };
+  return (
+    <section className={sectionCss}>
+      <p className={subTitleCss}>
+        {props.name}
+        {props.required && <span className={asterisk}>*</span>}
+      </p>
+
+      <div
+        className={css(inputWrapperCss, {
+          borderColor: errorMsg ? 'red.red500' : isFocused ? 'purple.purple500' : 'border.default',
+        })}
+      >
+        <input
+          className={inputCss}
+          required
+          autoComplete="off"
+          value={value}
+          onChange={handleChange}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+          {...props}
+        />
+        <Button
+          size="small"
+          variant="secondary"
+          type="button"
+          className={buttonCss}
+          onClick={onDoubleCheck}
+          disabled={doubleCheckabled}
+        >
+          중복확인
+        </Button>
+      </div>
+
+      {/* 닉네임 사용 가능 시 positive 컬러로 보여주기 추가 예정 */}
+      <div className={descriptionCss}>
+        {/* 처음엔 안보이다가 input의 길이가 너무 길면 빨간색으로 표시 */}
+        <span
+          className={css(descriptionTextCss, {
+            color: statusColor,
+          })}
+        >
+          {errorMsg || props.description}
+        </span>
+
+        {props.maxLength && (
+          <span className={css(inputLengthWrapperCss, { color: statusColor })}>
+            <strong
+              className={css({
+                color: errorMsg ? 'red.red500' : 'text.tertiary',
+              })}
+            >
+              {value.length}
+            </strong>
+            /{props.maxLength}
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}
+
+const descriptionCss = css({
+  display: 'flex',
+  justifyContent: 'space-between',
+  marginTop: '12px',
+  textStyle: 'body6',
+});
+
+const inputWrapperCss = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  width: '100%',
+  borderBottomWidth: '1px',
+  padding: '14px 4px',
+  height: '50px',
+  _focusWithin: { outline: 'none' },
+  boxSizing: 'border-box',
+  backgroundColor: 'bg.surface2',
+};
+
+const subTitleCss = css({
+  textStyle: 'body5',
+  color: 'text.primary',
+});
+
+const asterisk = css({
+  color: 'red.red500',
+  fontWeight: 'bold',
+  marginLeft: '2px',
+});
+
+const inputCss = css({
+  flex: 1,
+  height: '22px',
+  textStyle: 'subtitle3',
+  color: 'text.secondary',
+  backgroundColor: 'bg.surface2',
+  _focus: { outline: 'none' },
+  _placeholder: { color: 'gray.gray300' },
+});
+
+const inputLengthWrapperCss = {
+  textStyle: 'body6',
+  color: 'text.tertiary',
+};
+
+const descriptionTextCss = {
+  color: 'bg.surface1',
+};
+
+const buttonCss = css({
+  marginLeft: '12px',
+});
+
+const sectionCss = css({
+  _focusWithin: {},
+});

--- a/src/components/Input/NormalButtonInput.tsx
+++ b/src/components/Input/NormalButtonInput.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { type NormalButtonInputTypes } from '@/components/Input/Input.types';
 import { css } from '@/styled-system/css';
+import { getBorderColor } from '@/utils/getBorderColor';
 
 import Button from '../Button/Button';
 
@@ -27,7 +28,6 @@ export default function NormalButtonInput({
     }
 
     onChange?.(inputValue);
-    //
     setDoubleCheckAbled(inputValue.length === 0);
   };
 
@@ -35,6 +35,7 @@ export default function NormalButtonInput({
     //TODO: 중복확인 로직
     alert('중복확인 로직 추가');
   };
+
   return (
     <section className={sectionCss}>
       <p className={subTitleCss}>
@@ -44,7 +45,7 @@ export default function NormalButtonInput({
 
       <div
         className={css(inputWrapperCss, {
-          borderColor: errorMsg ? 'red.red500' : isFocused ? 'purple.purple500' : 'border.default',
+          borderColor: getBorderColor(errorMsg, isFocused),
         })}
       >
         <input

--- a/src/components/Input/NormalButtonInput.tsx
+++ b/src/components/Input/NormalButtonInput.tsx
@@ -68,7 +68,7 @@ export default function NormalButtonInput({
           onClick={onDoubleCheck}
           disabled={doubleCheckabled}
         >
-          중복확인
+          {props.text}
         </Button>
       </div>
 

--- a/src/components/Input/NormalButtonInput.tsx
+++ b/src/components/Input/NormalButtonInput.tsx
@@ -16,16 +16,12 @@ export default function NormalButtonInput({
   const [isFocused, setIsFocused] = useState(false);
 
   const statusColor = errorMsg ? 'red.red500' : 'text.tertiary';
-  //닉네임 사용 가능시 디스크립션에 보여줄 positiveColor
-  // const positiveColor = positiveMsg ? 'blue.blue500' : 'text.tertiary';
 
-  //중복확인 버튼이 사용 가능할지에 대한 상태. 네이밍 논의 필요.
   const [doubleCheckabled, setDoubleCheckAbled] = useState(false);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const inputValue = e.target.value;
 
-    // input의 기본 속성인 maxLength만으로는 한글 대응이 불가능.
     if (props.maxLength && inputValue.length > props.maxLength) {
       return;
     }
@@ -73,9 +69,7 @@ export default function NormalButtonInput({
         </Button>
       </div>
 
-      {/* 닉네임 사용 가능 시 positive 컬러로 보여주기 추가 예정 */}
       <div className={descriptionCss}>
-        {/* 처음엔 안보이다가 input의 길이가 너무 길면 빨간색으로 표시 */}
         <span
           className={css(descriptionTextCss, {
             color: statusColor,

--- a/src/components/Input/NormalButtonInput.tsx
+++ b/src/components/Input/NormalButtonInput.tsx
@@ -58,7 +58,7 @@ export default function NormalButtonInput({
           {...props}
         />
         <Button size="small" variant="secondary" type="button" className={buttonCss} onClick={onDoubleCheck}>
-          {props.text}
+          {props.buttonText}
         </Button>
       </div>
 

--- a/src/components/Input/NormalButtonInput.tsx
+++ b/src/components/Input/NormalButtonInput.tsx
@@ -11,7 +11,7 @@ export default function NormalButtonInput({
   value,
   onChange,
   errorMsg,
-  positiveMsg,
+  validMsg,
   required = false,
   ...props
 }: NormalButtonInputTypes) {

--- a/src/components/Input/NormalButtonInput.tsx
+++ b/src/components/Input/NormalButtonInput.tsx
@@ -19,8 +19,6 @@ export default function NormalButtonInput({
 
   const statusColor = errorMsg ? 'red.red500' : 'text.tertiary';
 
-  const [doubleCheckabled, setDoubleCheckAbled] = useState(false);
-
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const inputValue = e.target.value;
 
@@ -29,7 +27,6 @@ export default function NormalButtonInput({
     }
 
     onChange?.(inputValue);
-    setDoubleCheckAbled(inputValue.length === 0);
   };
 
   const onDoubleCheck = () => {
@@ -60,14 +57,7 @@ export default function NormalButtonInput({
           {...(required && { required: true })}
           {...props}
         />
-        <Button
-          size="small"
-          variant="secondary"
-          type="button"
-          className={buttonCss}
-          onClick={onDoubleCheck}
-          disabled={doubleCheckabled}
-        >
+        <Button size="small" variant="secondary" type="button" className={buttonCss} onClick={onDoubleCheck}>
           {props.text}
         </Button>
       </div>

--- a/src/components/Input/NormalButtonInput.tsx
+++ b/src/components/Input/NormalButtonInput.tsx
@@ -12,6 +12,7 @@ export default function NormalButtonInput({
   onChange,
   errorMsg,
   positiveMsg,
+  required = false,
   ...props
 }: NormalButtonInputTypes) {
   const [isFocused, setIsFocused] = useState(false);
@@ -40,7 +41,7 @@ export default function NormalButtonInput({
     <section className={sectionCss}>
       <p className={subTitleCss}>
         {props.name}
-        {props.required && <span className={asterisk}>*</span>}
+        {required && <span className={asterisk}>*</span>}
       </p>
 
       <div
@@ -56,6 +57,7 @@ export default function NormalButtonInput({
           onChange={handleChange}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
+          {...(required && { required: true })}
           {...props}
         />
         <Button

--- a/src/components/Input/NormalInput.tsx
+++ b/src/components/Input/NormalInput.tsx
@@ -14,7 +14,6 @@ export default function NormalInput({ value, onChange, errorMsg, ...props }: Nor
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const inputValue = e.target.value;
 
-    // input의 기본 속성인 maxLength만으로는 한글 대응이 불가능.
     if (props.maxLength && inputValue.length > props.maxLength) {
       return;
     }
@@ -54,7 +53,6 @@ export default function NormalInput({ value, onChange, errorMsg, ...props }: Nor
       </div>
 
       <div className={descriptionCss}>
-        {/* 처음엔 안보이다가 input의 길이가 너무 길면 빨간색으로 표시 */}
         <span
           className={css(descriptionTextCss, {
             color: statusColor,

--- a/src/components/Input/NormalInput.tsx
+++ b/src/components/Input/NormalInput.tsx
@@ -9,7 +9,7 @@ import Icon from '../Icon';
 export default function NormalInput({ value, onChange, errorMsg, ...props }: NormalInputType) {
   const [isFocused, setIsFocused] = useState(false);
 
-  const statusColor = errorMsg ? 'red.red500' : isFocused ? 'purple.purple500' : 'text.tertiary';
+  const statusColor = errorMsg ? 'red.red500' : 'text.tertiary';
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const inputValue = e.target.value;
@@ -67,13 +67,7 @@ export default function NormalInput({ value, onChange, errorMsg, ...props }: Nor
           <span className={css(inputLengthWrapperCss, { color: statusColor })}>
             <strong
               className={css({
-                color: errorMsg
-                  ? 'red.red500'
-                  : isFocused
-                    ? 'purple.purple500'
-                    : value.length === 0
-                      ? 'text.tertiary'
-                      : 'text.secondary',
+                color: errorMsg ? 'red.red500' : 'text.tertiary',
               })}
             >
               {value.length}

--- a/src/utils/getBorderColor.ts
+++ b/src/utils/getBorderColor.ts
@@ -1,0 +1,11 @@
+export const getBorderColor = (errorMsg: string | undefined, isFocused: boolean): string => {
+  if (isFocused) {
+    return 'purple.purple500';
+  }
+
+  if (errorMsg) {
+    return 'red.red500';
+  }
+
+  return 'border.default';
+};


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
close #254 

## 🎉 변경 사항
- 01/01 디자인 시스템의 변경된 사항인 Input variant:normal-button 추가
- Input 우측 하단의 글자수의 컬러를 몇 자를 입력하든 text/tertiary 로 통일했습니다.

### 🙏 여기는 꼭 봐주세요!
-  secondary 버튼의 disabled 상태 시 css가 brightness(0.4) 로 되어있어서 0.9로 수정했습니다! 다른 페이지에서 disabled인 small 버튼을 사용하는 곳이 없는 것 같기도 하고, 디자인 팀에서도 disabled 버튼을 컬러 코드가 아닌 퍼센테이지로 관리하는 게 좋겠다고 하셔서 수정해봤어요.
- Input 컴포넌트에 normal-button 케이스를 추가하니까 기존 normal 인풋이 에러가 나네요...TS 에 무지한 저를 도와주시면 감사합니다 😭
![image](https://github.com/depromeet/10mm-client-web/assets/67476544/492296fc-33b4-4a8a-b7a4-ec76e0163507)

### 사용 방법

## 🌄 스크린샷
![image](https://github.com/depromeet/10mm-client-web/assets/67476544/7a6083c0-6540-4547-86c0-02c3222a1744)

## 📚 참고
