### PR TITLE
:sparkles: TextButtonHeaderType 에 rightButtonProps 타입 추가

### DIFF
--- a/src/app/mission/[id]/detail/modify/page.tsx
+++ b/src/app/mission/[id]/detail/modify/page.tsx
@@ -56,9 +56,7 @@ export default function MissionModifyPage() {
       <Header
         rightAction="text-button"
         title={'미션 수정'}
-        rightButtonText={'저장'}
-        onButtonClick={modifyTest}
-        rightButtonDisabled={isButtonDisabled}
+        rightButtonProps={{ disabled: isButtonDisabled, onClick: modifyTest }}
       />
       <div className={containerCss}>
         <Input

--- a/src/app/mypage/profile_modify/page.tsx
+++ b/src/app/mypage/profile_modify/page.tsx
@@ -28,8 +28,7 @@ function ProfileModifyPage() {
       <Header
         rightAction="text-button"
         title="프로필 수정"
-        rightButtonDisabled={isSubmitButtonDisabled}
-        onButtonClick={onSubmit}
+        rightButtonProps={{ disabled: isSubmitButtonDisabled, onClick: onSubmit }}
       />
 
       <main className={mainCss}>

--- a/src/app/record/detail/[id]/MissionRecordHeader.tsx
+++ b/src/app/record/detail/[id]/MissionRecordHeader.tsx
@@ -13,7 +13,9 @@ function MissionRecordHeader({ recordId }: { recordId: string }) {
       rightAction="text-button"
       title={'미션 내역'}
       rightButtonText={'수정'}
-      onButtonClick={handleEditButtonClick}
+      rightButtonProps={{
+        onClick: handleEditButtonClick,
+      }}
     />
   );
 }

--- a/src/app/record/detail/[id]/edit/page.tsx
+++ b/src/app/record/detail/[id]/edit/page.tsx
@@ -29,7 +29,9 @@ function MissionRecordEditPage({ params }: { params: { id: string } }) {
         rightAction="text-button"
         title={'일지 수정'}
         rightButtonText={'저장'}
-        onButtonClick={handleSaveButtonClick}
+        rightButtonProps={{
+          onClick: handleSaveButtonClick,
+        }}
       />
       <TextArea count placeholder={'일지를 입력해주세요'} onChange={handleChange} value={value} />
     </main>

--- a/src/app/record/detail/empty/page.tsx
+++ b/src/app/record/detail/empty/page.tsx
@@ -6,7 +6,14 @@ import { stack } from '@styled-system/patterns';
 function MissionRecordEmptyPage() {
   return (
     <main className={mainWrapperCss}>
-      <Header rightAction="text-button" title={'미션 내역'} rightButtonText={'수정'} rightButtonDisabled={true} />
+      <Header
+        rightAction="text-button"
+        title={'미션 내역'}
+        rightButtonText={'수정'}
+        rightButtonProps={{
+          disabled: true,
+        }}
+      />
 
       <div className={containerCss}>
         <Empty type={'notice'} title={'미션 인증 내역이 없어요.'} image={'docs'} description={''} />

--- a/src/components/Header/Header.types.ts
+++ b/src/components/Header/Header.types.ts
@@ -1,3 +1,5 @@
+import { type ComponentProps } from 'react';
+import type Button from '@/components/Button/Button';
 import { type IconComponentMap } from '@/components/Icon';
 import { type MenuBaseItem } from '@/components/Menu';
 
@@ -24,6 +26,7 @@ export interface TextButtonHeaderType extends HeaderBaseType {
   rightButtonText?: string;
   onButtonClick?: () => void;
   rightButtonDisabled?: boolean;
+  rightButtonProps?: Omit<ComponentProps<typeof Button>, 'children' | 'variant' | 'size'>;
 }
 
 export interface IconMenuHeaderType extends HeaderBaseType {

--- a/src/components/Header/Header.types.ts
+++ b/src/components/Header/Header.types.ts
@@ -24,8 +24,6 @@ export interface NoneHeaderType extends HeaderBaseType {
 export interface TextButtonHeaderType extends HeaderBaseType {
   rightAction: 'text-button';
   rightButtonText?: string;
-  onButtonClick?: () => void;
-  rightButtonDisabled?: boolean;
   rightButtonProps?: Omit<ComponentProps<typeof Button>, 'children' | 'variant' | 'size'>;
 }
 

--- a/src/components/Header/TextButtonHeader.tsx
+++ b/src/components/Header/TextButtonHeader.tsx
@@ -2,23 +2,11 @@ import Button from '@/components/Button/Button';
 import { type TextButtonHeaderType } from '@/components/Header/Header.types';
 import HeaderBase from '@/components/Header/HeaderBase';
 
-function TextButtonHeader({
-  rightButtonText = '완료',
-  rightButtonDisabled,
-  onButtonClick,
-  rightButtonProps,
-  ...props
-}: TextButtonHeaderType) {
+function TextButtonHeader({ rightButtonText = '완료', rightButtonProps, ...props }: TextButtonHeaderType) {
   return (
     <HeaderBase
       rightElement={
-        <Button
-          variant="ghost"
-          size="medium"
-          onClick={onButtonClick}
-          disabled={rightButtonDisabled}
-          {...rightButtonProps}
-        >
+        <Button variant="ghost" size="medium" {...rightButtonProps}>
           {rightButtonText}
         </Button>
       }

--- a/src/components/Header/TextButtonHeader.tsx
+++ b/src/components/Header/TextButtonHeader.tsx
@@ -6,12 +6,19 @@ function TextButtonHeader({
   rightButtonText = '완료',
   rightButtonDisabled,
   onButtonClick,
+  rightButtonProps,
   ...props
 }: TextButtonHeaderType) {
   return (
     <HeaderBase
       rightElement={
-        <Button variant="ghost" size="medium" onClick={onButtonClick} disabled={rightButtonDisabled}>
+        <Button
+          variant="ghost"
+          size="medium"
+          onClick={onButtonClick}
+          disabled={rightButtonDisabled}
+          {...rightButtonProps}
+        >
           {rightButtonText}
         </Button>
       }

--- a/src/components/Input/DropdownInput.tsx
+++ b/src/components/Input/DropdownInput.tsx
@@ -95,7 +95,15 @@ interface DropdownProps<T extends string>
 function Dropdown<T extends string>(props: DropdownProps<T>) {
   return (
     <BottomSheet
-      headerElement={<Header rightAction="text-button" title="카테고리" onButtonClick={props.onClickOutside} />}
+      headerElement={
+        <Header
+          rightAction="text-button"
+          title="카테고리"
+          rightButtonProps={{
+            onClick: props.onClickOutside,
+          }}
+        />
+      }
       {...props}
     >
       <ul className={dropdownListCss}>


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
TextButtonHeader 을 사용할때 text button으로 form에 대한 대이터를 제출하는 ui가 종종 보였습니다 (수정, 제출 등) 
제어 컴포넌트로 진행한다면 현재 구조로 구현하는데에 문제가 없지만, 
비제어 컴포넌트로 form 제출을 위해서는 button type과 form 등의 attribute 들을 header 컴포넌트를 사용하는 곳에서 넣어주어야하는 필요성이 생겼습니다.

ComponentProps<typeof Button> 의 타입 중에 이미 디자인적으로 정해져서 컴포넌트내에서 결정되거나 다른 prop으로 주입하고 있었던  타입들을 제외하고 넣을 수 있게 하였습니다. 

## 🎉 변경 사항
TextButtonHeader props 타입에 버튼에 대한 타입인 rightButtonProps 을 추가했습니다.
### 🙏 여기는 꼭 봐주세요!
1. rightButtonProps 를 객체로 받는것이 좋은 구조인지 모르겠습니다. 
처음에는 

```ts
export interface TextButtonHeaderType extends HeaderBaseType, Omit<ComponentProps<typeof Button>, 'children' | 'variant' | 'size'> {
  rightAction: 'text-button';
  rightButtonText?: string;
  onButtonClick?: () => void;
  rightButtonDisabled?: boolean;
}

```
로 모두 열었지만 header 에 관련된 props 와 button에 관련된 props가 섞이는게 헷갈릴수도 있겠다 싶어서 객체로 묶어서 주입하도록 설계했습니다.

2.   onButtonClick, rightButtonDisabled 모두 button 의 props 에 있는 onClick 과 disabled 로 변경가능하기 때문에 rightButtonProps 에서 받을지 현재 상태에서 추가로 붙는 button Props 들(추가 option느낌)만 rightButtonProps 에서 넣을 수 있게 할지 고민이였습니다. 현재는 기본 구조를 크게 해치고 싶지 않아서 props 추가로만 대응한 상태입니다.

### 사용 방법

## 🌄 스크린샷

## 📚 참고
