### PR TITLE
[Design] input component 수정

### DIFF
--- a/src/components/Input/Input.stories.ts
+++ b/src/components/Input/Input.stories.ts
@@ -86,3 +86,26 @@ export const Dropdown: Story = {
     placeholder: '카테고리를 선택해주세요.',
   },
 };
+
+export const NormalButtonInput: Story = {
+  args: {
+    onTextButtonClick: () => alert('버튼 클릭'),
+    variant: 'normal-button',
+    name: '미션명',
+    placeholder: '미션명을 입력하세요',
+    value: '운동',
+    description: '디스크립션 영역입니다',
+    buttonText: '확인',
+    required: false,
+    maxLength: 20,
+    errorMsg: '',
+  },
+  argTypes: {
+    title: { table: { disable: true } },
+    onSelect: { table: { disable: true } },
+    onChange: { table: { disable: true } },
+    selected: { table: { disable: true } },
+    list: { table: { disable: true } },
+    variant: { table: { disable: true } },
+  },
+};

--- a/src/components/Input/Input.types.ts
+++ b/src/components/Input/Input.types.ts
@@ -6,8 +6,8 @@ interface InputBaseType {
 
 export interface NormalInputType extends InputBaseType, Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
   variant?: 'normal';
-  value: string;
   onChange?: (value: string) => void;
+  value?: string;
 
   description?: string;
   errorMsg?: string;
@@ -21,13 +21,14 @@ export interface DropdownValueType<Value = string> {
 
 export interface NormalButtonInputTypes extends InputBaseType, Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
   variant: 'normal-button';
-  value: string;
   onChange?: (value: string) => void;
+  value?: string;
 
   description?: string;
   errorMsg?: string;
   validMsg?: string;
   required?: boolean;
+
   buttonText: string;
 }
 

--- a/src/components/Input/Input.types.ts
+++ b/src/components/Input/Input.types.ts
@@ -30,6 +30,7 @@ export interface NormalButtonInputTypes extends InputBaseType, Omit<InputHTMLAtt
   required?: boolean;
 
   buttonText: string;
+  onTextButtonClick: () => void;
 }
 
 export interface DropDownInputType<T extends string> extends InputBaseType {

--- a/src/components/Input/NormalButtonInput.tsx
+++ b/src/components/Input/NormalButtonInput.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { useState } from 'react';
 import { type NormalButtonInputTypes } from '@/components/Input/Input.types';
 import { css } from '@/styled-system/css';
@@ -10,6 +8,7 @@ import Button from '../Button/Button';
 export default function NormalButtonInput({
   value,
   onChange,
+  onTextButtonClick,
   errorMsg,
   validMsg,
   required = false,
@@ -54,7 +53,7 @@ export default function NormalButtonInput({
           {...(required && { required: true })}
           {...props}
         />
-        <Button size="small" variant="secondary" type="button" className={buttonCss} onClick={onDoubleCheck}>
+        <Button size="small" variant="secondary" type="button" className={buttonCss} onClick={onTextButtonClick}>
           {props.buttonText}
         </Button>
       </div>

--- a/src/components/Input/NormalButtonInput.tsx
+++ b/src/components/Input/NormalButtonInput.tsx
@@ -32,10 +32,10 @@ export default function NormalButtonInput({
 
   return (
     <section className={sectionCss}>
-      <p className={subTitleCss}>
+      <label className={subTitleCss} htmlFor={props.id}>
         {props.name}
         {required && <span className={asterisk}>*</span>}
-      </p>
+      </label>
 
       <div
         className={css(inputWrapperCss, {

--- a/src/components/Input/NormalButtonInput.tsx
+++ b/src/components/Input/NormalButtonInput.tsx
@@ -29,10 +29,7 @@ export default function NormalButtonInput({
     onChange?.(inputValue);
   };
 
-  const onDoubleCheck = () => {
-    //TODO: 중복확인 로직
-    alert('중복확인 로직 추가');
-  };
+  const isMaxLengthTextVisible = value && props.maxLength;
 
   return (
     <section className={sectionCss}>
@@ -71,7 +68,7 @@ export default function NormalButtonInput({
           {errorMsg || props.description}
         </span>
 
-        {props.maxLength && (
+        {isMaxLengthTextVisible && (
           <span className={css(inputLengthWrapperCss, { color: statusColor })}>
             <strong
               className={css({

--- a/src/components/Input/NormalButtonInput.tsx
+++ b/src/components/Input/NormalButtonInput.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { type NormalButtonInputTypes } from '@/components/Input/Input.types';
-import { css } from '@/styled-system/css';
+import { css, cx } from '@/styled-system/css';
 import { getBorderColor } from '@/utils/getBorderColor';
 
 import Button from '../Button/Button';
@@ -38,9 +38,12 @@ export default function NormalButtonInput({
       </label>
 
       <div
-        className={css(inputWrapperCss, {
-          borderColor: getBorderColor(errorMsg, isFocused),
-        })}
+        className={cx(
+          inputWrapperCss,
+          css({
+            borderColor: getBorderColor(errorMsg, isFocused),
+          }),
+        )}
       >
         <input
           className={inputCss}
@@ -68,7 +71,7 @@ export default function NormalButtonInput({
         </span>
 
         {isMaxLengthTextVisible && (
-          <span className={css(inputLengthWrapperCss, { color: statusColor })}>
+          <span className={cx(inputLengthWrapperCss, css({ color: statusColor }))}>
             <strong
               className={css({
                 color: errorMsg ? 'red.red500' : 'text.tertiary',
@@ -91,7 +94,7 @@ const descriptionCss = css({
   textStyle: 'body6',
 });
 
-const inputWrapperCss = {
+const inputWrapperCss = css({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
@@ -102,7 +105,7 @@ const inputWrapperCss = {
   _focusWithin: { outline: 'none' },
   boxSizing: 'border-box',
   backgroundColor: 'bg.surface2',
-};
+});
 
 const subTitleCss = css({
   textStyle: 'body5',
@@ -125,10 +128,10 @@ const inputCss = css({
   _placeholder: { color: 'gray.gray300' },
 });
 
-const inputLengthWrapperCss = {
+const inputLengthWrapperCss = css({
   textStyle: 'body6',
   color: 'text.tertiary',
-};
+});
 
 const descriptionTextCss = {
   color: 'bg.surface1',

--- a/src/components/Input/NormalButtonInput.tsx
+++ b/src/components/Input/NormalButtonInput.tsx
@@ -139,5 +139,6 @@ const buttonCss = css({
 });
 
 const sectionCss = css({
+  width: '100%',
   _focusWithin: {},
 });

--- a/src/components/Input/NormalInput.tsx
+++ b/src/components/Input/NormalInput.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { type NormalInputType } from '@/components/Input/Input.types';
-import { css } from '@/styled-system/css';
+import { css, cx } from '@/styled-system/css';
 
 import Icon from '../Icon';
 
@@ -36,9 +36,12 @@ export default function NormalInput({ value, onChange, errorMsg, ...props }: Nor
       </label>
 
       <div
-        className={css(inputWrapperCss, {
-          borderColor: errorMsg ? 'red.red500' : isFocused ? 'purple.purple500' : 'border.default',
-        })}
+        className={cx(
+          inputWrapperCss,
+          css({
+            borderColor: errorMsg ? 'red.red500' : isFocused ? 'purple.purple500' : 'border.default',
+          }),
+        )}
       >
         <input
           className={inputCss}
@@ -57,15 +60,18 @@ export default function NormalInput({ value, onChange, errorMsg, ...props }: Nor
 
       <div className={descriptionCss}>
         <span
-          className={css(descriptionTextCss, {
-            color: statusColor,
-          })}
+          className={cx(
+            descriptionTextCss,
+            css({
+              color: statusColor,
+            }),
+          )}
         >
           {errorMsg || props.description}
         </span>
 
         {isMaxLengthTextVisible && (
-          <span className={css(inputLengthWrapperCss, { color: statusColor })}>
+          <span className={cx(inputLengthWrapperCss, css({ color: statusColor }))}>
             <strong
               className={css({
                 color: errorMsg ? 'red.red500' : 'text.tertiary',
@@ -88,7 +94,7 @@ const descriptionCss = css({
   textStyle: 'body6',
 });
 
-const inputWrapperCss = {
+const inputWrapperCss = css({
   display: 'flex',
   justifyContent: 'space-between',
   width: '100%',
@@ -98,7 +104,7 @@ const inputWrapperCss = {
   _focusWithin: { outline: 'none' },
   boxSizing: 'border-box',
   backgroundColor: 'bg.surface2',
-};
+});
 
 const subTitleCss = css({
   textStyle: 'body5',
@@ -121,14 +127,14 @@ const inputCss = css({
   _placeholder: { color: 'gray.gray300' },
 });
 
-const inputLengthWrapperCss = {
+const inputLengthWrapperCss = css({
   textStyle: 'body6',
   color: 'text.tertiary',
-};
+});
 
-const descriptionTextCss = {
+const descriptionTextCss = css({
   color: 'bg.surface1',
-};
+});
 
 const iconCss = css({
   cursor: 'pointer',

--- a/src/components/Input/NormalInput.tsx
+++ b/src/components/Input/NormalInput.tsx
@@ -30,10 +30,10 @@ export default function NormalInput({ value, onChange, errorMsg, ...props }: Nor
 
   return (
     <section className={sectionCss}>
-      <p className={subTitleCss}>
+      <label className={subTitleCss} htmlFor={props.id}>
         {props.name}
         {props.required && <span className={asterisk}>*</span>}
-      </p>
+      </label>
 
       <div
         className={css(inputWrapperCss, {

--- a/src/components/Input/NormalInput.tsx
+++ b/src/components/Input/NormalInput.tsx
@@ -136,5 +136,6 @@ const iconCss = css({
 });
 
 const sectionCss = css({
+  width: '100%',
   _focusWithin: {},
 });

--- a/src/components/Input/NormalInput.tsx
+++ b/src/components/Input/NormalInput.tsx
@@ -25,6 +25,9 @@ export default function NormalInput({ value, onChange, errorMsg, ...props }: Nor
     onChange?.('');
   };
 
+  const isDeleteButtonVisible = value && value.length > 0;
+  const isMaxLengthTextVisible = value && props.maxLength;
+
   return (
     <section className={sectionCss}>
       <p className={subTitleCss}>
@@ -47,7 +50,7 @@ export default function NormalInput({ value, onChange, errorMsg, ...props }: Nor
           onBlur={() => setIsFocused(false)}
           {...props}
         />
-        {value.length > 0 && (
+        {isDeleteButtonVisible && (
           <Icon name={'close-circle'} color={'icon.tertiary'} className={iconCss} onClick={onDelete} />
         )}
       </div>
@@ -61,7 +64,7 @@ export default function NormalInput({ value, onChange, errorMsg, ...props }: Nor
           {errorMsg || props.description}
         </span>
 
-        {props.maxLength && (
+        {isMaxLengthTextVisible && (
           <span className={css(inputLengthWrapperCss, { color: statusColor })}>
             <strong
               className={css({


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
- NormalButtonInput, NormalInput 에서 value type optional이 아니여서 비제어 컴포넌트로 form을 만들지 못하는 문제가 있었습니다. 
- NormalButtonInput 컴포넌트에서 중복수정 로직이 있는 것보다는 컴포넌트 바깥에서 다루는게 좋을 것 같아서 수정했습니다.
- NormalButtonInput에 대한 스토리가 없어서 추가하였습니다.

## 🎉 변경 사항
-  NormalButtonInput, NormalInput의 value를 optional로 변경
- [NormalButtonInput props에 onTextButtonClick 추가](https://github.com/depromeet/10mm-client-web/commit/18a785a429ea9e23f4b4038b934a51a701a5a8b0)
- input 에 해당하는 라벨을 나타내는 텍스트들을 label 태그로 변경하였습니다. 
- input 컴포넌트 width 100% 변경

### 🙏 여기는 꼭 봐주세요!

### 사용 방법

## 🌄 스크린샷
- 컴포넌트 width를 100% 로 변경하여도 아래 뷰에서 크게 깨지지는 않았으나 혹시 우려되는 점있으시면 리
뷰 남겨주세요 

<img width="605" alt="스크린샷 2024-01-15 오전 3 28 31" src="https://github.com/depromeet/10mm-client-web/assets/68339352/6a9c3f6e-a739-46f9-a2b0-99acaa8f267d">

## 📚 참고
