### PR TITLE
[Task] 임시 로그인 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,7 @@
 const nextConfig = {
   experimental: {
     instrumentationHooks: true,
+    serverActions: true,
   },
 };
 

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,0 +1,80 @@
+import apiInstance from '@/apis/instance.api';
+import { storeToken } from '@/services/auth/actions';
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import { type AxiosError } from 'axios';
+
+interface LoginRequest {
+  username: string;
+  password: string;
+}
+
+interface LoginResponse {
+  accessToken: string;
+  refreshToken: string;
+}
+
+interface RegisterRequest {
+  nickname: string;
+}
+
+interface CheckUsernameRequest {
+  username: string;
+}
+
+export const AUTH_APIS = {
+  login: async (request: LoginRequest): Promise<LoginResponse> => {
+    const { data } = await apiInstance.post('/auth/login', {
+      ...request,
+    });
+    await storeToken(data);
+    return data;
+  },
+
+  tempRegister: async (request: LoginRequest): Promise<LoginResponse> => {
+    const { data } = await apiInstance.post('/auth/temp-register', {
+      ...request,
+    });
+    await storeToken(data);
+    return data;
+  },
+
+  register: async (request: RegisterRequest) => {
+    const { data } = await apiInstance.post('/auth/register', {
+      ...request,
+    });
+    return data;
+  },
+  checkUsername: (data: CheckUsernameRequest) => {
+    return apiInstance.post(`/auth/check-username`, {
+      ...data,
+    });
+  },
+};
+
+export const useTempRegister = (option?: UseMutationOptions<LoginResponse, AxiosError, LoginRequest>) => {
+  return useMutation({
+    mutationFn: AUTH_APIS.tempRegister,
+
+    ...option,
+  });
+};
+
+export const useLogin = (option?: UseMutationOptions<LoginResponse, AxiosError, LoginRequest>) => {
+  return useMutation({
+    mutationFn: AUTH_APIS.login,
+    onSuccess: (...data) => {
+      option?.onSuccess?.(...data);
+    },
+    onError: (...data) => {
+      option?.onError?.(...data);
+    },
+    ...option,
+  });
+};
+
+export const useNicknameRegister = (option?: UseMutationOptions<RegisterRequest, AxiosError, RegisterRequest>) => {
+  return useMutation({
+    mutationFn: AUTH_APIS.register,
+    ...option,
+  });
+};

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -12,9 +12,16 @@ export default function LoginPage() {
     router.push(ROUTER.GUEST.MISSION.NEW);
   };
 
+  const onClickLoginButton = () => {
+    router.push(ROUTER.AUTH.SIGNIN);
+  };
+
   return (
     <main className={MainWrapperCss}>
       <div className={LoginButtonListWrapperCss}>
+        <Button variant="primary" size="large" onClick={onClickLoginButton}>
+          아이디로 로그인
+        </Button>
         <ButtonSocialLogin type="kakao" />
         <ButtonSocialLogin type="apple" />
         <Button size="large" variant="ghost" onClick={onClickGuest}>
@@ -42,6 +49,7 @@ const MainWrapperCss = css({
 });
 
 const LoginButtonListWrapperCss = css({
+  maxWidth: '320px',
   display: 'flex',
   gap: '8px',
   flexDirection: 'column',

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -2,7 +2,6 @@
 
 import { useRouter } from 'next/navigation';
 import Button from '@/components/Button/Button';
-import ButtonSocialLogin from '@/components/ButtonSocialLogin/ButtonSocialLogin';
 import { ROUTER } from '@/constants/router';
 import { css } from '@styled-system/css';
 
@@ -22,8 +21,8 @@ export default function LoginPage() {
         <Button variant="primary" size="large" onClick={onClickLoginButton}>
           아이디로 로그인
         </Button>
-        <ButtonSocialLogin type="kakao" />
-        <ButtonSocialLogin type="apple" />
+        {/*<ButtonSocialLogin type="kakao" />*/}
+        {/*<ButtonSocialLogin type="apple" />*/}
         <Button size="large" variant="ghost" onClick={onClickGuest}>
           둘러보기
         </Button>

--- a/src/app/auth/nickname/page.tsx
+++ b/src/app/auth/nickname/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import router from 'next/router';
+import { useRouter } from 'next/navigation';
 import { useNicknameRegister } from '@/apis/auth';
 import { isSeverError } from '@/apis/instance.api';
 import Button from '@/components/Button/Button';
@@ -13,7 +13,7 @@ import { css } from '@styled-system/css';
 
 export default function AuthNickNamePage() {
   const [nickname, setNickname] = useState('');
-
+  const router = useRouter();
   const { triggerSnackBar } = useSnackBar();
   const { mutate } = useNicknameRegister({
     onSuccess: () => {

--- a/src/app/auth/nickname/page.tsx
+++ b/src/app/auth/nickname/page.tsx
@@ -2,14 +2,32 @@
 
 import { useState } from 'react';
 import router from 'next/router';
+import { useNicknameRegister } from '@/apis/auth';
+import { isSeverError } from '@/apis/instance.api';
 import Button from '@/components/Button/Button';
 import Header from '@/components/Header/Header';
 import Input from '@/components/Input/Input';
+import { useSnackBar } from '@/components/SnackBar/SnackBarProvider';
 import { ROUTER } from '@/constants/router';
 import { css } from '@styled-system/css';
 
 export default function AuthNickNamePage() {
   const [nickname, setNickname] = useState('');
+
+  const { triggerSnackBar } = useSnackBar();
+  const { mutate } = useNicknameRegister({
+    onSuccess: () => {
+      router.push(ROUTER.HOME);
+    },
+    onError: (error) => {
+      if (isSeverError(error)) {
+        triggerSnackBar({
+          message: error.data.message,
+        });
+        return;
+      }
+    },
+  });
 
   const handleNickname = (value: string) => {
     setNickname(value);
@@ -17,9 +35,9 @@ export default function AuthNickNamePage() {
 
   const isSubmitButtonDisabled = !nickname;
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!nickname) return;
-    router.push(ROUTER.HOME);
+    mutate({ nickname });
   };
 
   return (

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import Button from '@/components/Button/Button';
+import Input from '@/components/Input/Input';
+import { ROUTER } from '@/constants/router';
+import { css } from '@styled-system/css';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const onClickSignUp = () => {
+    router.push(ROUTER.AUTH.SIGNUP);
+  };
+
+  return (
+    <form className={mainWrapperCss}>
+      <Input id={'userId'} name={'아이디'} variant={'normal'} value={''} />
+      <Input id={'password'} name={'비밀번호'} variant={'normal'} type={'password'} value={''} />
+      <Button variant="primary" size="large">
+        로그인
+      </Button>
+      <Button variant="ghost" size="large" onClick={onClickSignUp}>
+        회원가입
+      </Button>
+    </form>
+  );
+}
+
+const mainWrapperCss = css({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '0 40px',
+  width: '100%',
+  height: '100vh',
+
+  color: 'text.primary',
+  gap: '32px',
+
+  '& section': {
+    width: '100%',
+  },
+});

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,24 +1,66 @@
 'use client';
+
+import { type FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
+import { useLogin } from '@/apis/auth';
+import { isSeverError } from '@/apis/instance.api';
 import Button from '@/components/Button/Button';
 import Input from '@/components/Input/Input';
+import { useSnackBar } from '@/components/SnackBar/SnackBarProvider';
 import { ROUTER } from '@/constants/router';
 import { css } from '@styled-system/css';
 
-export default function LoginPage() {
+export default function SigninPage() {
+  const { triggerSnackBar } = useSnackBar();
+
   const router = useRouter();
-  const onClickSignUp = () => {
+
+  const { mutate } = useLogin({
+    onSuccess: () => {
+      router.push(ROUTER.HOME);
+    },
+    onError: (error) => {
+      if (isSeverError(error)) {
+        triggerSnackBar({
+          message: error.data.message,
+        });
+        return;
+      }
+    },
+  });
+
+  const onClick = () => {
     router.push(ROUTER.AUTH.SIGNUP);
   };
 
+  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.target as HTMLFormElement);
+
+    const username = formData.get('아이디');
+    const password = formData.get('비밀번호');
+
+    if (!username || !password) {
+      triggerSnackBar({
+        message: '아이디와 비밀번호를 입력해주세요.',
+      });
+      return;
+    }
+
+    mutate({
+      username: username.toString(),
+      password: password.toString(),
+    });
+  };
+
   return (
-    <form className={mainWrapperCss}>
-      <Input id={'userId'} name={'아이디'} variant={'normal'} value={''} />
-      <Input id={'password'} name={'비밀번호'} variant={'normal'} type={'password'} value={''} />
+    <form className={mainWrapperCss} onSubmit={onSubmit}>
+      <Input id={'userId'} name={'아이디'} variant={'normal'} />
+      <Input id={'password'} name={'비밀번호'} variant={'normal'} type={'password'} />
       <Button variant="primary" size="large">
         로그인
       </Button>
-      <Button variant="ghost" size="large" onClick={onClickSignUp}>
+      <Button variant="ghost" size="large" type={'button'} onClick={onClick}>
         회원가입
       </Button>
     </form>

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+import Button from '@/components/Button/Button';
+import Input from '@/components/Input/Input';
+import { css } from '@styled-system/css';
+
+export default function SignupPage() {
+  return (
+    <form className={mainWrapperCss}>
+      <Input id={'userId'} name={'아이디'} variant={'normal'} value={''} />
+      <Input id={'password'} name={'비밀번호'} variant={'normal'} type={'password'} value={''} />
+      <Input id={'password-confirm'} name={'비밀번호 확인'} variant={'normal'} type={'password'} value={''} />
+
+      <Button variant="primary" size="large">
+        회원가입
+      </Button>
+    </form>
+  );
+}
+
+const mainWrapperCss = css({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '0 40px',
+  width: '100%',
+  height: '100vh',
+
+  color: 'text.primary',
+  gap: '32px',
+
+  '& section': {
+    width: '100%',
+  },
+});

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -1,14 +1,65 @@
 'use client';
+import { type FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTempRegister } from '@/apis/auth';
+import { isSeverError } from '@/apis/instance.api';
 import Button from '@/components/Button/Button';
 import Input from '@/components/Input/Input';
+import { useSnackBar } from '@/components/SnackBar/SnackBarProvider';
+import { ROUTER } from '@/constants/router';
 import { css } from '@styled-system/css';
 
 export default function SignupPage() {
+  const { triggerSnackBar } = useSnackBar();
+  const router = useRouter();
+
+  const { mutate } = useTempRegister({
+    onSuccess: () => {
+      router.push(ROUTER.AUTH.NICKNAME);
+    },
+    onError: (error) => {
+      if (isSeverError(error)) {
+        triggerSnackBar({
+          message: error.data.message,
+        });
+        return;
+      }
+    },
+  });
+
+  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.target as HTMLFormElement);
+
+    const username = formData.get('아이디');
+    const password = formData.get('비밀번호');
+    const passwordConfirm = formData.get('비밀번호 확인');
+
+    if (formData.get('비밀번호') !== formData.get('비밀번호 확인')) {
+      triggerSnackBar({
+        message: '비밀번호가 일치하지 않습니다.',
+      });
+      return;
+    }
+
+    if (!username || !password || !passwordConfirm) {
+      triggerSnackBar({
+        message: '아이디와 비밀번호를 입력해주세요.',
+      });
+      return;
+    }
+
+    mutate({
+      username: username.toString(),
+      password: password.toString(),
+    });
+  };
+
   return (
-    <form className={mainWrapperCss}>
-      <Input id={'userId'} name={'아이디'} variant={'normal'} value={''} />
-      <Input id={'password'} name={'비밀번호'} variant={'normal'} type={'password'} value={''} />
-      <Input id={'password-confirm'} name={'비밀번호 확인'} variant={'normal'} type={'password'} value={''} />
+    <form className={mainWrapperCss} onSubmit={onSubmit}>
+      <Input id={'userId'} name={'아이디'} variant={'normal'} />
+      <Input id={'password'} name={'비밀번호'} variant={'normal'} type={'password'} />
+      <Input id={'password-confirm'} name={'비밀번호 확인'} variant={'normal'} type={'password'} />
 
       <Button variant="primary" size="large">
         회원가입

--- a/src/app/mypage/LogoutDialog.tsx
+++ b/src/app/mypage/LogoutDialog.tsx
@@ -1,9 +1,16 @@
+import { useRouter } from 'next/navigation';
 import Dialog from '@/components/Dialog/Dialog';
 import { type ModalProps } from '@/components/Modal/Modal';
+import { ROUTER } from '@/constants/router';
+import { removeTokens } from '@/services/auth/actions';
 
 function LogoutDialog(props: ModalProps) {
+  const router = useRouter();
   // TODO : logout 동작
-  const onLogout = () => {};
+  const onLogout = async () => {
+    await removeTokens();
+    router.push(ROUTER.AUTH.LOGIN);
+  };
 
   return (
     <Dialog

--- a/src/components/Input/NormalButtonInput.tsx
+++ b/src/components/Input/NormalButtonInput.tsx
@@ -124,6 +124,7 @@ const inputCss = css({
   textStyle: 'subtitle3',
   color: 'text.secondary',
   backgroundColor: 'bg.surface2',
+
   _focus: { outline: 'none' },
   _placeholder: { color: 'gray.gray300' },
 });

--- a/src/constants/router.ts
+++ b/src/constants/router.ts
@@ -31,6 +31,8 @@ export const ROUTER = {
   },
   AUTH: {
     LOGIN: '/auth/login',
+    SIGNUP: '/auth/signup',
+    SIGNIN: '/auth/signin',
   },
   GUEST: {
     MISSION: {

--- a/src/constants/router.ts
+++ b/src/constants/router.ts
@@ -33,6 +33,7 @@ export const ROUTER = {
     LOGIN: '/auth/login',
     SIGNUP: '/auth/signup',
     SIGNIN: '/auth/signin',
+    NICKNAME: '/auth/nickname',
   },
   GUEST: {
     MISSION: {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,17 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const cookie = request.cookies;
+  const refreshToken = cookie.get('refreshToken') ? cookie.get('refreshToken')?.value : null;
+  const accessToken = cookie.get('accessToken') ? cookie.get('accessToken')?.value : null;
+
+  if (!refreshToken || !accessToken) {
+    return NextResponse.redirect(new URL('/auth/login', request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: '/((?!api|_next/static|_next/image|favicon.ico|auth|images|mockServiceWorker.js).*)',
+};

--- a/src/services/auth/actions.ts
+++ b/src/services/auth/actions.ts
@@ -34,3 +34,8 @@ export async function getTokens() {
     refreshToken: refreshToken ? refreshToken.value : null,
   };
 }
+
+export async function removeTokens() {
+  cookies().delete('accessToken');
+  cookies().delete('refreshToken');
+}

--- a/src/services/auth/actions.ts
+++ b/src/services/auth/actions.ts
@@ -1,0 +1,36 @@
+'use server';
+
+import { cookies } from 'next/headers';
+
+interface StoreTokenRequest {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export async function storeToken(request: StoreTokenRequest) {
+  cookies().set({
+    name: 'accessToken',
+    value: request.accessToken,
+    httpOnly: true,
+    sameSite: 'strict',
+    secure: true,
+  });
+
+  cookies().set({
+    name: 'refreshToken',
+    value: request.refreshToken,
+    httpOnly: true,
+    sameSite: 'strict',
+    secure: true,
+  });
+}
+
+export async function getTokens() {
+  const accessToken = cookies().get('accessToken');
+  const refreshToken = cookies().get('refreshToken');
+
+  return {
+    accessToken: accessToken ? accessToken.value : null,
+    refreshToken: refreshToken ? refreshToken.value : null,
+  };
+}


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
#32 

## 🎉 변경 사항
- 임시 로그인 페이지 
- 회원가입 페이지
- 닉네임 입력 페이지

- 로그인시 cookie 에 atk rtk 모두 저장
- 회원가입시 cookie 에 atk rtk 모두 저장
- 토큰 없을 시 middleware 에서 redirect


구현 해야하는 것 
- 로그인 화면 UI 조금 손봐야해요
- 로그아웃 기능 
- missions api 리스폰스 달라졌는데 그거 적용해야해요
- sever response type 일괄 처리  (data.data)

### 🙏 여기는 꼭 봐주세요!
- sever action (use sever) 을 사용하기 위해서 experimental :  { severAction : true } 옵션 추가하였습니다 
- 미들웨어에서 리다이렉트하는 방법 중에 놓치는게 있다면 알려주세요 

현재 토큰 저장과 사용에는 문제없슴을 확인했습니다 이어서 로그아웃 바로 구현하겠습니다 (개발하는데는 문제없어서 PR생성합니다)
### 사용 방법

## 🌄 스크린샷

## 📚 참고
https://nextjs.org/docs/app/building-your-application/routing/middleware
https://react.dev/reference/react/use-server