### PR TITLE
[Fix] 미션 생성 페이지 수정

### DIFF
--- a/src/app/mission/new/MissionRegistration.tsx
+++ b/src/app/mission/new/MissionRegistration.tsx
@@ -48,7 +48,6 @@ export default function MissionRegistration() {
         maxLength={20}
         value={missionTitleInput}
         onChange={handleMissionTitleInput}
-        description="디스크립션 영역입니다"
       />
       <Input
         type="text"
@@ -57,7 +56,6 @@ export default function MissionRegistration() {
         maxLength={30}
         value={missionContentInput}
         onChange={handleMissionContentInput}
-        description="디스크립션 영역입니다"
       />
 
       {/* 카테고리 */}

--- a/src/components/Input/Input.types.ts
+++ b/src/components/Input/Input.types.ts
@@ -7,7 +7,7 @@ interface InputBaseType {
 export interface NormalInputType extends InputBaseType, Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
   variant?: 'normal';
   onChange?: (value: string) => void;
-  value?: string;
+  value: string;
 
   description?: string;
   errorMsg?: string;

--- a/src/components/Input/Input.types.ts
+++ b/src/components/Input/Input.types.ts
@@ -7,7 +7,7 @@ interface InputBaseType {
 export interface NormalInputType extends InputBaseType, Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
   variant?: 'normal';
   onChange?: (value: string) => void;
-  value: string;
+  value?: string;
 
   description?: string;
   errorMsg?: string;

--- a/src/components/Input/NormalInput.tsx
+++ b/src/components/Input/NormalInput.tsx
@@ -26,6 +26,7 @@ export default function NormalInput({ value, onChange, errorMsg, ...props }: Nor
   };
 
   const isDeleteButtonVisible = value && value.length > 0;
+  // const isMaxLengthTextVisible = value && props.maxLength;
 
   return (
     <section className={sectionCss}>
@@ -75,7 +76,7 @@ export default function NormalInput({ value, onChange, errorMsg, ...props }: Nor
               color: errorMsg ? 'red.red500' : 'text.tertiary',
             })}
           >
-            {value.length}
+            {value?.length}
           </strong>
           /{props.maxLength}
         </span>

--- a/src/components/Input/NormalInput.tsx
+++ b/src/components/Input/NormalInput.tsx
@@ -26,7 +26,6 @@ export default function NormalInput({ value, onChange, errorMsg, ...props }: Nor
   };
 
   const isDeleteButtonVisible = value && value.length > 0;
-  const isMaxLengthTextVisible = value && props.maxLength;
 
   return (
     <section className={sectionCss}>
@@ -70,18 +69,16 @@ export default function NormalInput({ value, onChange, errorMsg, ...props }: Nor
           {errorMsg || props.description}
         </span>
 
-        {isMaxLengthTextVisible && (
-          <span className={cx(inputLengthWrapperCss, css({ color: statusColor }))}>
-            <strong
-              className={css({
-                color: errorMsg ? 'red.red500' : 'text.tertiary',
-              })}
-            >
-              {value.length}
-            </strong>
-            /{props.maxLength}
-          </span>
-        )}
+        <span className={cx(inputLengthWrapperCss, css({ color: statusColor }))}>
+          <strong
+            className={css({
+              color: errorMsg ? 'red.red500' : 'text.tertiary',
+            })}
+          >
+            {value.length}
+          </strong>
+          /{props.maxLength}
+        </span>
       </div>
     </section>
   );


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

## 🎉 변경 사항
- 미션 생성 페이지의 디스크립션 영역을 제거했습니다
- 첨부한 영상과 같이 Input 우측 하단의 글자수 세기 영역이 디자인 시스템과 다르게 글자를 입력해야 보이는 부분을 수정했습니다.

### 🙏 여기는 꼭 봐주세요!

### 사용 방법

## 🌄 스크린샷

https://github.com/depromeet/10mm-client-web/assets/67476544/9c72dbef-03bb-43c6-8e5b-72657521c829



## 📚 참고
