### PR TITLE
[Feat] 중복 체크기능 구현

### DIFF
--- a/src/apis/member.ts
+++ b/src/apis/member.ts
@@ -18,6 +18,10 @@ interface CheckUsernameRequest {
   username: string;
 }
 
+interface CheckNicknameRequest {
+  nickname: string;
+}
+
 interface UploadProfileImageCompleteRequest extends Partial<UploadBaseRequest> {
   nickname: string;
 }
@@ -39,6 +43,11 @@ const MEMBER_API = {
     const { data } = await apiInstance.post(`/members/check-username`, request);
     return data;
   },
+
+  checkNickname: async (request: CheckNicknameRequest) => {
+    const { data } = await apiInstance.post(`/members/check-nickname`, request);
+    return data;
+  },
   uploadProfileImage: async (request: UploadBaseRequest): Promise<UploadUrlBaseResponse> => {
     const { data } = await apiInstance.post<UploadUrlBaseResponse>(`/members/me/upload-url`, request);
     return data;
@@ -52,6 +61,13 @@ const MEMBER_API = {
 export const useCheckUsername = (option?: UseMutationOptions<unknown, unknown, CheckUsernameRequest>) => {
   return useMutation({
     mutationFn: MEMBER_API.checkUsername,
+    ...option,
+  });
+};
+
+export const useCheckNickname = (option?: UseMutationOptions<unknown, unknown, CheckNicknameRequest>) => {
+  return useMutation({
+    mutationFn: MEMBER_API.checkNickname,
     ...option,
   });
 };

--- a/src/app/auth/nickname/page.tsx
+++ b/src/app/auth/nickname/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useNicknameRegister } from '@/apis/auth';
 import { isSeverError } from '@/apis/instance.api';
@@ -9,10 +8,12 @@ import Header from '@/components/Header/Header';
 import Input from '@/components/Input/Input';
 import { useSnackBar } from '@/components/SnackBar/SnackBarProvider';
 import { ROUTER } from '@/constants/router';
+import useNickname from '@/hooks/useNickname';
 import { css } from '@styled-system/css';
 
 export default function AuthNickNamePage() {
-  const [nickname, setNickname] = useState('');
+  const { nickname, handleNicknameChange, massageState, handleDuplicateCheck } = useNickname();
+
   const router = useRouter();
   const { triggerSnackBar } = useSnackBar();
   const { mutate } = useNicknameRegister({
@@ -29,10 +30,6 @@ export default function AuthNickNamePage() {
     },
   });
 
-  const handleNickname = (value: string) => {
-    setNickname(value);
-  };
-
   const isSubmitButtonDisabled = !nickname;
 
   const handleSubmit = async () => {
@@ -48,14 +45,19 @@ export default function AuthNickNamePage() {
           <div className={subTitleCss}>닉네임을 설정해주세요.</div>
           <div className={subTitleDescriptionCss}>20자 이내의 한글, 영문, 숫자 입력이 가능합니다.</div>
         </div>
+
         <Input
-          type="text"
+          variant="normal-button"
+          value={nickname}
+          onChange={handleNicknameChange}
           placeholder="닉네임을 입력하세요"
           name="닉네임"
-          required
           maxLength={20}
-          value={nickname}
-          onChange={handleNickname}
+          buttonText="중복확인"
+          buttonDisabeld={Boolean(massageState.errorMsg)}
+          errorMsg={massageState.errorMsg}
+          validMsg={massageState.validMsg}
+          onTextButtonClick={handleDuplicateCheck}
         />
         <div className={buttonContainerCss}>
           <Button variant={'cta'} size={'medium'} onClick={handleSubmit} disabled={isSubmitButtonDisabled}>

--- a/src/app/mypage/profile_modify/page.tsx
+++ b/src/app/mypage/profile_modify/page.tsx
@@ -19,9 +19,12 @@ function ProfileModifyPage() {
 
   const [nickname, setNickname] = useState(data?.nickname || '');
 
+  const rightButtonDisabled = nickname.length === 0;
+
   const validateNickname = (value: string) => {
     const regex = /^[가-힣a-zA-Z0-9]{2,20}$/;
-    return regex.test(value);
+    const hasInvalidCharacter = /^[\wㄱ-ㅎㅏ-ㅣ가-힣]*$/.test(value);
+    return regex.test(value) && hasInvalidCharacter;
   };
   const isValid = validateNickname(nickname);
 
@@ -77,7 +80,7 @@ function ProfileModifyPage() {
       <Header
         rightAction="text-button"
         title="프로필 수정"
-        rightButtonProps={{ disabled: nickname.length === 0, onClick: onSubmit }}
+        rightButtonProps={{ disabled: rightButtonDisabled, onClick: onSubmit }}
       />
 
       <main className={mainCss}>

--- a/src/app/mypage/profile_modify/page.tsx
+++ b/src/app/mypage/profile_modify/page.tsx
@@ -18,7 +18,9 @@ function ProfileModifyPage() {
   const router = useRouter();
 
   const [nickname, setNickname] = useState(data?.nickname || '');
+  const [validNickname, setValidNickname] = useState(true);
 
+  //TODO: 완료 버튼 disabled되는 조건 추가 -> 이미지가 바뀌지 않았을경우, 기존 닉네임에서 바뀐게 없을 경우, 중복확인 결과 사용 불가능한 닉네임일 경우
   const rightButtonDisabled = nickname.length === 0;
 
   const validateNickname = (value: string) => {
@@ -53,6 +55,12 @@ function ProfileModifyPage() {
 
   const handleImageClick = () => {
     imageRef.current?.click();
+  };
+
+  const handleDuplicateCheck = () => {
+    //TODO: 중복체크 확인 API 나오면 작업 예정
+    setValidNickname((prev) => !prev);
+    console.log(validNickname);
   };
 
   const onSubmit = async () => {
@@ -110,6 +118,7 @@ function ProfileModifyPage() {
           buttonText="중복확인"
           buttonDisabeld={duplicateCheckButtonDisabled}
           errorMsg={errorMsg}
+          onTextButtonClick={handleDuplicateCheck}
         />
         ;
       </main>

--- a/src/app/mypage/profile_modify/page.tsx
+++ b/src/app/mypage/profile_modify/page.tsx
@@ -17,9 +17,18 @@ function ProfileModifyPage() {
 
   const router = useRouter();
 
-  const [nickname, setUserNickname] = useState(data?.nickname || '');
+  const [nickname, setNickname] = useState(data?.nickname || '');
+
+  const validateNickname = (value: string) => {
+    const regex = /^[가-힣a-zA-Z0-9]{2,20}$/;
+    return regex.test(value);
+  };
+  const isValid = validateNickname(nickname);
+
+  const errorMsg = isValid ? '' : '2~20자 이내의 한글, 영문, 숫자로만 입력해 주세요.';
 
   const imageRef = useRef<HTMLInputElement>(null);
+  const duplicateCheckButtonDisabled = data?.nickname === nickname || !isValid;
 
   const { uploadImageChange, imagePreview, imageFile } = useImage(data?.profileImageUrl || '');
   const { triggerSnackBar } = useSnackBar();
@@ -89,7 +98,17 @@ function ProfileModifyPage() {
             <Icon name="camera" width={14} height={14} color="icon.secondary" />
           </div>
         </section>
-        <Input value={nickname} onChange={setUserNickname} name="닉네임" maxLength={20} />;
+        <Input
+          variant="normal-button"
+          value={nickname}
+          onChange={setNickname}
+          name="닉네임"
+          maxLength={20}
+          buttonText="중복확인"
+          buttonDisabeld={duplicateCheckButtonDisabled}
+          errorMsg={errorMsg}
+        />
+        ;
       </main>
     </>
   );

--- a/src/app/mypage/profile_modify/page.tsx
+++ b/src/app/mypage/profile_modify/page.tsx
@@ -2,7 +2,7 @@
 
 import { type ChangeEvent, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { useGetMembersMe, useUploadProfileImage, useUploadProfileImageComplete } from '@/apis/member';
+import { useCheckNickname, useGetMembersMe, useUploadProfileImage, useUploadProfileImageComplete } from '@/apis/member';
 import Header from '@/components/Header/Header';
 import Icon from '@/components/Icon';
 import Input from '@/components/Input/Input';
@@ -15,10 +15,27 @@ import { css } from '@/styled-system/css';
 function ProfileModifyPage() {
   const { data } = useGetMembersMe();
 
-  const router = useRouter();
-
   const [nickname, setNickname] = useState(data?.nickname || '');
+
+  const { mutate } = useCheckNickname();
   const [validNickname, setValidNickname] = useState(true);
+  const handleDuplicateCheck = () => {
+    mutate(
+      { nickname },
+      {
+        onSuccess: () => {
+          console.log('뮤테이션 성공');
+          setValidNickname(true);
+        },
+        onError: () => {
+          console.log('뮤테이션 에러');
+          setValidNickname(false);
+        },
+      },
+    );
+  };
+
+  const router = useRouter();
 
   //TODO: 완료 버튼 disabled되는 조건 추가 -> 이미지가 바뀌지 않았을경우, 기존 닉네임에서 바뀐게 없을 경우, 중복확인 결과 사용 불가능한 닉네임일 경우
   const rightButtonDisabled = nickname.length === 0;
@@ -31,6 +48,10 @@ function ProfileModifyPage() {
   const isValid = validateNickname(nickname);
 
   const errorMsg = isValid ? '' : '2~20자 이내의 한글, 영문, 숫자로만 입력해 주세요.';
+
+  const description = validNickname
+    ? '사용 가능한 닉네임입니다.'
+    : '중복된 닉네임입니다. 다른 닉네임으로 변경해주세요.';
 
   const imageRef = useRef<HTMLInputElement>(null);
   const duplicateCheckButtonDisabled = data?.nickname === nickname || !isValid;
@@ -55,12 +76,6 @@ function ProfileModifyPage() {
 
   const handleImageClick = () => {
     imageRef.current?.click();
-  };
-
-  const handleDuplicateCheck = () => {
-    //TODO: 중복체크 확인 API 나오면 작업 예정
-    setValidNickname((prev) => !prev);
-    console.log(validNickname);
   };
 
   const onSubmit = async () => {
@@ -118,6 +133,7 @@ function ProfileModifyPage() {
           buttonText="중복확인"
           buttonDisabeld={duplicateCheckButtonDisabled}
           errorMsg={errorMsg}
+          description={description}
           onTextButtonClick={handleDuplicateCheck}
         />
         ;

--- a/src/components/Input/Input.stories.ts
+++ b/src/components/Input/Input.stories.ts
@@ -99,6 +99,7 @@ export const NormalButtonInput: Story = {
     required: false,
     maxLength: 20,
     errorMsg: '',
+    buttonDisabeld: true,
   },
   argTypes: {
     title: { table: { disable: true } },

--- a/src/components/Input/Input.types.ts
+++ b/src/components/Input/Input.types.ts
@@ -28,6 +28,7 @@ export interface NormalButtonInputTypes extends InputBaseType, Omit<InputHTMLAtt
   errorMsg?: string;
   validMsg?: string;
   required?: boolean;
+  buttonDisabeld: boolean;
 
   buttonText: string;
   onTextButtonClick: () => void;

--- a/src/components/Input/NormalButtonInput.tsx
+++ b/src/components/Input/NormalButtonInput.tsx
@@ -28,9 +28,7 @@ export default function NormalButtonInput({
 
     onChange?.(inputValue);
   };
-
   const isMaxLengthTextVisible = value && props.maxLength;
-
   return (
     <section className={sectionCss}>
       <label className={subTitleCss} htmlFor={props.id}>
@@ -72,10 +70,10 @@ export default function NormalButtonInput({
       <div className={descriptionCss}>
         <span
           className={css(descriptionTextCss, {
-            color: statusColor,
+            color: props.description ? '' : validMsg ? 'blue.blue500' : 'red.red500',
           })}
         >
-          {errorMsg || props.description}
+          {errorMsg || validMsg || props.description}
         </span>
 
         {isMaxLengthTextVisible && (

--- a/src/components/Input/NormalButtonInput.tsx
+++ b/src/components/Input/NormalButtonInput.tsx
@@ -80,14 +80,7 @@ export default function NormalButtonInput({
 
         {isMaxLengthTextVisible && (
           <span className={cx(inputLengthWrapperCss, css({ color: statusColor }))}>
-            <strong
-              className={css({
-                color: errorMsg ? 'red.red500' : 'text.tertiary',
-              })}
-            >
-              {value.length}
-            </strong>
-            /{props.maxLength}
+            <strong>{value.length}</strong>/{props.maxLength}
           </span>
         )}
       </div>

--- a/src/components/Input/NormalButtonInput.tsx
+++ b/src/components/Input/NormalButtonInput.tsx
@@ -12,6 +12,7 @@ export default function NormalButtonInput({
   errorMsg,
   validMsg,
   required = false,
+  buttonDisabeld,
   ...props
 }: NormalButtonInputTypes) {
   const [isFocused, setIsFocused] = useState(false);
@@ -56,7 +57,14 @@ export default function NormalButtonInput({
           {...(required && { required: true })}
           {...props}
         />
-        <Button size="small" variant="secondary" type="button" className={buttonCss} onClick={onTextButtonClick}>
+        <Button
+          size="small"
+          variant="secondary"
+          type="button"
+          className={buttonCss}
+          onClick={onTextButtonClick}
+          disabled={buttonDisabeld}
+        >
           {props.buttonText}
         </Button>
       </div>

--- a/src/hooks/useNickname.ts
+++ b/src/hooks/useNickname.ts
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { useCheckNickname } from '@/apis/member';
+
+const useNickname = (initialNickName?: string) => {
+  const { mutate } = useCheckNickname();
+  const [nickname, setNickname] = useState(initialNickName || '');
+  const [massageState, setMassageState] = useState({
+    errorMsg: '',
+    validMsg: '',
+  });
+
+  const handleDuplicateCheck = () => {
+    mutate(
+      { nickname },
+      {
+        onSuccess: () => {
+          setMassageState({
+            errorMsg: '',
+            validMsg: '사용 가능한 닉네임입니다.',
+          });
+        },
+        onError: () => {
+          setMassageState({
+            errorMsg: '중복된 닉네임입니다. 다른 닉네임으로 변경해주세요.',
+            validMsg: '',
+          });
+        },
+      },
+    );
+  };
+
+  const handleNicknameChange = (value: string) => {
+    setNickname(value);
+
+    if (!validateNickname(value)) {
+      setMassageState({
+        errorMsg: '2~20자 이내의 한글, 영문, 숫자로만 입력해 주세요.',
+        validMsg: '',
+      });
+      return;
+    }
+    setMassageState({
+      errorMsg: '',
+      validMsg: '',
+    });
+  };
+
+  return {
+    nickname,
+    massageState,
+    handleNicknameChange,
+    handleDuplicateCheck,
+  };
+};
+
+const validateNickname = (value: string) => {
+  const regex = /^[가-힣a-zA-Z0-9]{2,20}$/;
+  const hasInvalidCharacter = /^[\wㄱ-ㅎㅏ-ㅣ가-힣]*$/.test(value);
+  return regex.test(value) && hasInvalidCharacter;
+};
+
+export default useNickname;


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
closed #320 


## 🎉 변경 사항
- 프로필 수정 페이지에서 닉네임 중복체크 기능을 구현했습니다.
-  red.red500이 value.length 에도 들어가있어서 수정했습니다.

### 🙏 여기는 꼭 봐주세요!
- 뮤테이션 성공 시 디스크립션을 띄워주는데 현재 컬러가 text.tertiary 입니다. 현재 profile_modify/page.tsx에서 validNickname 상태로 닉네임의 사용 가능 여부를 나타내는데, 이 상태를 가지고 normal-button Input 에서 컬러 값을 바꾸는 방식이 맞는지 모르겠습니다. 코멘트 주시면 수정해보겠습니다!

### 사용 방법

## 🌄 스크린샷
![image](https://github.com/depromeet/10mm-client-web/assets/67476544/f38eb911-791b-4113-b1f2-1c24480e5d5f)
![image](https://github.com/depromeet/10mm-client-web/assets/67476544/24ef17be-cd13-4c03-bcf6-4f4a1247a91f)


## 📚 참고
