### PR TITLE
fix : useSuspense query 대신 useQuery 로 변경

### DIFF
--- a/src/apis/record.ts
+++ b/src/apis/record.ts
@@ -1,7 +1,13 @@
 import { createQueryKeyFactory } from '@/apis/createQueryKeyFactory';
 import { type RecordType } from '@/apis/schema/record';
 import { type UploadBaseRequest } from '@/apis/schema/upload';
-import { useMutation, type UseMutationOptions, type UseQueryOptions, useSuspenseQuery } from '@tanstack/react-query';
+import {
+  useMutation,
+  type UseMutationOptions,
+  useQuery,
+  type UseQueryOptions,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
 
 import apiInstance from './instance.api';
 
@@ -83,7 +89,7 @@ export default RECORD_API;
 const getRecordQueryKey = createQueryKeyFactory<GetRecordsParams>('record');
 
 export const useGetRecord = (params: GetRecordsParams, option?: UseQueryOptions<GetRecordsResponse>) => {
-  return useSuspenseQuery({
+  return useQuery({
     queryKey: getRecordQueryKey(params),
     queryFn: () => RECORD_API.getRecords(params),
     ...option,

--- a/src/app/mission/[id]/detail/MissionCalender/MissionCalendar.tsx
+++ b/src/app/mission/[id]/detail/MissionCalender/MissionCalendar.tsx
@@ -41,7 +41,7 @@ function MissionCalendar({ currentDate, missionId }: { currentDate: Date; missio
                   <td key={`${day.year}-${day.month}-${day.date}`} className={missionCalendarTdCss}>
                     <MissionCalendarItem
                       date={day.date}
-                      {...getMissionCalendarItemProps(day.date, data)}
+                      {...getMissionCalendarItemProps(day.date, data || [])}
                       isActive={day.date === selectedDate}
                     />
                   </td>


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요
뒤로가기 할때 아래와 같은 이슈가 있어서 useSuspense query 대신 useQuery 로 변경
![스크린샷 2024-01-22 오후 11 04 31](https://github.com/depromeet/10mm-client-web/assets/68339352/5a626ced-840c-4db0-8ffb-bec84d2d7f92)

<!-- 관련 이슈를 적어주세요 -->
<!-- closed #1-->

## 🎉 변경 사항

### 🙏 여기는 꼭 봐주세요!

### 사용 방법

## 🌄 스크린샷

## 📚 참고
