### PR TITLE
[Feat] CardLevel 컴포넌트 생성

### DIFF
--- a/src/app/home/FollowSummary.tsx
+++ b/src/app/home/FollowSummary.tsx
@@ -2,7 +2,7 @@ import Banner from '@/components/Banner/Banner';
 import Icon from '@/components/Icon';
 import LevelProgressBar from '@/components/LevelStatus/LevelProgressBar';
 import Thumbnail from '@/components/Thumbnail/Thumbnail';
-import { gradientTextCss } from '@/constants/style/text';
+import { gradientTextCss } from '@/constants/style/gradient';
 import { css, cx } from '@styled-system/css';
 import { flex } from '@styled-system/patterns';
 

--- a/src/app/level/guide/Character.tsx
+++ b/src/app/level/guide/Character.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { css, cx } from '@/styled-system/css';
+import { css, cva, cx } from '@/styled-system/css';
 
 interface Props {
   width: number;
@@ -64,11 +64,70 @@ function Character(props: Props) {
 
 export default Character;
 
+interface LockedCharacterProps {
+  level: number;
+  size: 'md' | 'lg';
+}
+
+export function LockedCharacter(props: LockedCharacterProps) {
+  return (
+    <div key={props.level} className={cx(imageWrapperCss)}>
+      <Image
+        src={`/assets/character-by-level/locked/${props.level}.svg`}
+        alt="locked"
+        width={180}
+        height={180}
+        className={cx(imageCss, lockCharacterImageCva({ size: props.size }))}
+      />
+      <Image
+        src={`/assets/character-by-level/locked/lock.svg`}
+        alt="locked"
+        width={180}
+        height={180}
+        className={cx(imageCss, lockCoverImageCva({ size: props.size }))}
+      />
+    </div>
+  );
+}
+
+const lockCharacterImageCva = cva({
+  base: { position: 'absolute', top: 0, bottom: 0, left: 0, right: 0, margin: 'auto', animation: 'fadeIn .7s' },
+  variants: {
+    size: {
+      lg: {
+        width: '202px',
+        height: '151px',
+      },
+      md: {
+        width: '76px',
+        height: '56.8px',
+      },
+    },
+  },
+});
+
+const lockCoverImageCva = cva({
+  base: {},
+  variants: {
+    size: {
+      md: {
+        width: '72px',
+        height: '72px',
+      },
+      lg: {
+        width: '180px',
+        height: '180px',
+      },
+    },
+  },
+});
+
 const imageWrapperCss = css({
   position: 'relative',
   margin: '0 auto',
   animation: 'fadeIn .7s',
   height: '100%',
+  width: '100%',
 });
 
 const imageCss = css({

--- a/src/app/level/guide/Character.tsx
+++ b/src/app/level/guide/Character.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { css, cva, cx } from '@/styled-system/css';
+import { css, cx } from '@/styled-system/css';
 
 interface Props {
   width: number;
@@ -63,64 +63,6 @@ function Character(props: Props) {
 }
 
 export default Character;
-
-interface LockedCharacterProps {
-  level: number;
-  size: 'md' | 'lg';
-}
-
-export function LockedCharacter(props: LockedCharacterProps) {
-  return (
-    <div key={props.level} className={cx(imageWrapperCss)}>
-      <Image
-        src={`/assets/character-by-level/locked/${props.level}.svg`}
-        alt="locked"
-        width={180}
-        height={180}
-        className={cx(imageCss, lockCharacterImageCva({ size: props.size }))}
-      />
-      <Image
-        src={`/assets/character-by-level/locked/lock.svg`}
-        alt="locked"
-        width={180}
-        height={180}
-        className={cx(imageCss, lockCoverImageCva({ size: props.size }))}
-      />
-    </div>
-  );
-}
-
-const lockCharacterImageCva = cva({
-  base: { position: 'absolute', top: 0, bottom: 0, left: 0, right: 0, margin: 'auto', animation: 'fadeIn .7s' },
-  variants: {
-    size: {
-      lg: {
-        width: '202px',
-        height: '151px',
-      },
-      md: {
-        width: '76px',
-        height: '56.8px',
-      },
-    },
-  },
-});
-
-const lockCoverImageCva = cva({
-  base: {},
-  variants: {
-    size: {
-      md: {
-        width: '72px',
-        height: '72px',
-      },
-      lg: {
-        width: '180px',
-        height: '180px',
-      },
-    },
-  },
-});
 
 const imageWrapperCss = css({
   position: 'relative',

--- a/src/app/level/guide/GrowthLevel.tsx
+++ b/src/app/level/guide/GrowthLevel.tsx
@@ -3,30 +3,27 @@ import { LEVEL_SYSTEM } from '@/constants/level';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
 
-function GrowthLevel({
-  selectLevel,
-  maxLevel,
-  onClick,
-}: {
+interface Props {
   selectLevel: number;
   onClick: (level: number) => void;
   maxLevel: number;
-}) {
+}
+
+function GrowthLevel({ selectLevel, maxLevel, onClick }: Props) {
   return (
     <>
       <h2 className={headingCss}>성장 레벨</h2>
       <div className={containerCss}>
         <ul className={listContainerCss}>
-          {LEVEL_SYSTEM.map((level, idx) => {
+          {LEVEL_SYSTEM.map(({ level, label }, idx) => {
             const isLocked = maxLevel <= idx;
             return (
               <CardLevel
-                key={level.label}
-                // {...level}
-                level={level.level}
-                isSelected={selectLevel === level.level}
+                key={label}
+                level={level}
+                isSelected={selectLevel === level}
                 isLocked={isLocked}
-                onClick={() => onClick(level.level)}
+                onClick={() => onClick(level)}
               />
             );
           })}

--- a/src/app/level/guide/GrowthLevel.tsx
+++ b/src/app/level/guide/GrowthLevel.tsx
@@ -1,4 +1,4 @@
-import Character from '@/app/level/guide/Character';
+import Character, { LockedCharacter } from '@/app/level/guide/Character';
 import Icon from '@/components/Icon';
 import { LEVEL_SYSTEM, type LevelSystemType } from '@/constants/level';
 import { gradientTextCss } from '@/constants/style/text';
@@ -79,7 +79,11 @@ function GrowthLevelItem(props: GrowthLevelItemProps) {
     <li className={itemContainerRecipe({ selected: props.isSelected })} onClick={props.onClick}>
       <p className={levelLabelCss}>{props.level}</p>
       <div className={imageWrapperCss}>
-        <Character width={76} height={56.8} level={props.level} isLocked={props.isLocked} />
+        {props.isLocked ? (
+          <LockedCharacter level={props.level} size="md" />
+        ) : (
+          <Character width={76} height={56.8} level={props.level} isLocked={props.isLocked} />
+        )}
       </div>
       <div className={stackTextCss}>
         <Icon name={props.isLocked ? '10mm-symbol-circle-lock' : '10mm-symbol-circle'} />
@@ -125,6 +129,7 @@ const itemContainerRecipe = cva({
 
 const imageWrapperCss = center({
   flex: 1,
+  width: '100%',
 });
 
 const stackTextCss = flex({

--- a/src/app/level/guide/GrowthLevel.tsx
+++ b/src/app/level/guide/GrowthLevel.tsx
@@ -1,5 +1,6 @@
-import Character, { LockedCharacter } from '@/app/level/guide/Character';
+import Character from '@/app/level/guide/Character';
 import Icon from '@/components/Icon';
+import LockedCharacter from '@/components/Level/LockedCharacter';
 import { LEVEL_SYSTEM, type LevelSystemType } from '@/constants/level';
 import { gradientTextCss } from '@/constants/style/text';
 import { css, cva } from '@/styled-system/css';

--- a/src/app/level/guide/GrowthLevel.tsx
+++ b/src/app/level/guide/GrowthLevel.tsx
@@ -1,10 +1,7 @@
-import Character from '@/app/level/guide/Character';
-import Icon from '@/components/Icon';
-import LockedCharacter from '@/components/Level/LockedCharacter';
-import { LEVEL_SYSTEM, type LevelSystemType } from '@/constants/level';
-import { gradientTextCss } from '@/constants/style/text';
-import { css, cva } from '@/styled-system/css';
-import { center, flex } from '@/styled-system/patterns';
+import CardLevel from '@/components/Banner/CardLevel';
+import { LEVEL_SYSTEM } from '@/constants/level';
+import { css } from '@/styled-system/css';
+import { flex } from '@/styled-system/patterns';
 
 function GrowthLevel({
   selectLevel,
@@ -23,9 +20,10 @@ function GrowthLevel({
           {LEVEL_SYSTEM.map((level, idx) => {
             const isLocked = maxLevel <= idx;
             return (
-              <GrowthLevelItem
+              <CardLevel
                 key={level.label}
-                {...level}
+                // {...level}
+                level={level.level}
                 isSelected={selectLevel === level.level}
                 isLocked={isLocked}
                 onClick={() => onClick(level.level)}
@@ -67,75 +65,4 @@ const listContainerCss = flex({
   gap: '14px',
   padding: '12px 16px',
   width: 'fit-content',
-});
-
-interface GrowthLevelItemProps extends Pick<LevelSystemType, 'level' | 'min' | 'max' | 'imageUrl' | 'isFinal'> {
-  isSelected: boolean;
-  isLocked: boolean;
-  onClick: () => void;
-}
-
-function GrowthLevelItem(props: GrowthLevelItemProps) {
-  return (
-    <li className={itemContainerRecipe({ selected: props.isSelected })} onClick={props.onClick}>
-      <p className={levelLabelCss}>{props.level}</p>
-      <div className={imageWrapperCss}>
-        {props.isLocked ? (
-          <LockedCharacter level={props.level} size="md" />
-        ) : (
-          <Character width={76} height={56.8} level={props.level} isLocked={props.isLocked} />
-        )}
-      </div>
-      <div className={stackTextCss}>
-        <Icon name={props.isLocked ? '10mm-symbol-circle-lock' : '10mm-symbol-circle'} />
-        <p className={gradientTextCss}>
-          {props.min}~{props.max}
-        </p>
-      </div>
-    </li>
-  );
-}
-
-const levelLabelCss = css({
-  color: 'text.secondary',
-  textStyle: 'subtitle4',
-});
-
-const itemContainerRecipe = cva({
-  base: {
-    borderRadius: '22px',
-    flexDirection: 'column',
-    padding: '14px 16px',
-    width: '116px !',
-    height: '163px',
-    display: 'flex',
-    alignItems: 'center',
-    gap: '6px',
-    cursor: 'pointer',
-  },
-  variants: {
-    selected: {
-      true: {
-        border: '1px solid var(--gradient-primary, #FAD0DE)', //TODO : 수정
-        background: 'linear-gradient(93deg, rgba(25, 23, 27, 0.80) 0.82%, rgba(24, 25, 33, 0.80) 99.97%)',
-        boxShadow: '0px 5px 50px 4px rgba(92, 78, 122, 0.50) inset, 0px 4px 20px 0px rgba(16, 15, 23, 0.20)',
-        backdropBlur: 'blur(20px)',
-      },
-      false: {
-        backgroundColor: 'bg.surface3',
-      },
-    },
-  },
-});
-
-const imageWrapperCss = center({
-  flex: 1,
-  width: '100%',
-});
-
-const stackTextCss = flex({
-  width: 'fit-content',
-  gap: '2px',
-  alignItems: 'center',
-  textStyle: 'body1',
 });

--- a/src/app/level/guide/page.tsx
+++ b/src/app/level/guide/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useGetMissionSummary } from '@/apis/mission';
-import Character from '@/app/level/guide/Character';
+import Character, { LockedCharacter } from '@/app/level/guide/Character';
 import GrowthLevel from '@/app/level/guide/GrowthLevel';
 import LevelStatus from '@/components/LevelStatus/LevelStatus';
 import LoadingSpinner from '@/components/Loading/LoadingSpinner';
@@ -45,8 +45,9 @@ function LevelGuidePage() {
             </section>
             <section className={characterImageSectionCss}>
               {isLockedLevel ? (
-                <Character width={202} height={151} level={selectLevelInfo.level} isLocked={isLockedLevel} />
+                <LockedCharacter size="lg" level={selectLevelInfo.level} />
               ) : (
+                // <Character width={202} height={151} level={selectLevelInfo.level} isLocked={isLockedLevel} />
                 <Character
                   width={240}
                   height={180}

--- a/src/app/level/guide/page.tsx
+++ b/src/app/level/guide/page.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useState } from 'react';
 import { useGetMissionSummary } from '@/apis/mission';
-import Character, { LockedCharacter } from '@/app/level/guide/Character';
+import Character from '@/app/level/guide/Character';
 import GrowthLevel from '@/app/level/guide/GrowthLevel';
+import LockedCharacter from '@/components/Level/LockedCharacter';
 import LevelStatus from '@/components/LevelStatus/LevelStatus';
 import LoadingSpinner from '@/components/Loading/LoadingSpinner';
 import { LEVEL_SYSTEM } from '@/constants/level';

--- a/src/components/Banner/CardLevel.stories.tsx
+++ b/src/components/Banner/CardLevel.stories.tsx
@@ -1,0 +1,66 @@
+import { type ComponentProps } from 'react';
+import { LEVEL_SYSTEM } from '@/constants/level';
+import { flex } from '@/styled-system/patterns';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import CardLevel from './CardLevel';
+
+type Props = Pick<ComponentProps<typeof CardLevel>, 'isSelected' | 'isLocked'>;
+
+const CardLevelStory = (args: Props) => {
+  return (
+    <div className={flex({ gap: '14px' })}>
+      {LEVEL_SYSTEM.map((level) => (
+        <CardLevel key={level.level} level={level.level} {...args} />
+      ))}
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Component/Banner/CardLevel',
+  component: CardLevelStory,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    isLocked: false,
+    isSelected: false,
+  },
+  // argTypes: {
+  //   type: { table: { disable: true } },
+  // },
+} satisfies Meta<typeof CardLevel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    isLocked: false,
+    isSelected: false,
+  },
+};
+
+export const Locked: Story = {
+  args: {
+    isLocked: true,
+    isSelected: false,
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    isLocked: false,
+    isSelected: true,
+  },
+};
+
+export const LockedSelect: Story = {
+  args: {
+    isLocked: true,
+    isSelected: true,
+  },
+};

--- a/src/components/Banner/CardLevel.tsx
+++ b/src/components/Banner/CardLevel.tsx
@@ -1,0 +1,77 @@
+import Character from '@/app/level/guide/Character';
+import Icon from '@/components/Icon';
+import LockedCharacter from '@/components/Level/LockedCharacter';
+import { LEVEL_SYSTEM } from '@/constants/level';
+import { gradientBorderWrapperCss, gradientTextCss } from '@/constants/style/gradient';
+import { css, cx } from '@/styled-system/css';
+import { center, flex } from '@/styled-system/patterns';
+
+interface Props {
+  level: number;
+  isSelected: boolean;
+  isLocked: boolean;
+  onClick?: () => void;
+}
+
+function CardLevel(props: Props) {
+  const levelInfo = LEVEL_SYSTEM[props.level - 1];
+
+  return (
+    <li className={cx(itemContainerRecipe, props.isSelected ? gradientBorderWrapperCss() : '')} onClick={props.onClick}>
+      <div className={itemInnerContainerCss}>
+        <p className={levelLabelCss}>Lv. {levelInfo.level}</p>
+        <div className={imageWrapperCss}>
+          {props.isLocked ? (
+            <LockedCharacter level={levelInfo.level} size="md" />
+          ) : (
+            <Character width={76} height={56.8} level={levelInfo.level} isLocked={props.isLocked} />
+          )}
+        </div>
+        <div className={stackTextCss}>
+          <Icon name={props.isLocked ? '10mm-symbol-circle-lock' : '10mm-symbol-circle'} />
+          <p className={props.isLocked ? '' : gradientTextCss}>
+            {levelInfo.min}~{levelInfo.max}
+          </p>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+export default CardLevel;
+
+const levelLabelCss = css({
+  color: 'text.secondary',
+  textStyle: 'subtitle4',
+});
+
+const itemContainerRecipe = css({
+  borderRadius: '22px',
+  width: '116px!',
+  height: '163px',
+  backgroundColor: 'bg.surface3',
+  listStyle: 'none',
+});
+
+const itemInnerContainerCss = css({
+  width: '100%',
+  height: '100%',
+  flexDirection: 'column',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '6px',
+  padding: '14px 16px',
+});
+
+const imageWrapperCss = center({
+  flex: 1,
+  width: '100%',
+});
+
+const stackTextCss = flex({
+  width: 'fit-content',
+  gap: '2px',
+  alignItems: 'center',
+  textStyle: 'body1',
+  color: 'text.tertiary',
+});

--- a/src/components/Level/LockedCharacter.tsx
+++ b/src/components/Level/LockedCharacter.tsx
@@ -1,0 +1,79 @@
+import Image from 'next/image';
+import { css, cva, cx } from '@/styled-system/css';
+
+interface Props {
+  level: number;
+  size: 'md' | 'lg';
+}
+
+function LockedCharacter(props: Props) {
+  return (
+    <div key={props.level} className={cx(imageWrapperCss)}>
+      <Image
+        src={`/assets/character-by-level/locked/${props.level}.svg`}
+        alt="locked"
+        width={202}
+        height={151}
+        className={cx(imageCss, lockCharacterImageCva({ size: props.size }))}
+      />
+      <Image
+        src={`/assets/character-by-level/locked/lock.svg`}
+        alt="locked"
+        width={180}
+        height={180}
+        className={cx(imageCss, lockCoverImageCva({ size: props.size }))}
+      />
+    </div>
+  );
+}
+
+export default LockedCharacter;
+const lockCharacterImageCva = cva({
+  base: { position: 'absolute', top: 0, bottom: 0, left: 0, right: 0, margin: 'auto', animation: 'fadeIn .7s' },
+  variants: {
+    size: {
+      lg: {
+        width: '202px',
+        height: '151px',
+      },
+      md: {
+        width: '76px',
+        height: '56.8px',
+      },
+    },
+  },
+});
+
+const lockCoverImageCva = cva({
+  base: {},
+  variants: {
+    size: {
+      md: {
+        width: '72px',
+        height: '72px',
+      },
+      lg: {
+        width: '180px',
+        height: '180px',
+      },
+    },
+  },
+});
+
+const imageWrapperCss = css({
+  position: 'relative',
+  margin: '0 auto',
+  animation: 'fadeIn .7s',
+  height: '100%',
+  width: '100%',
+});
+
+const imageCss = css({
+  position: 'absolute',
+  top: 0,
+  bottom: 0,
+  left: 0,
+  right: 0,
+  margin: 'auto',
+  animation: 'fadeIn .7s',
+});

--- a/src/components/LevelStatus/LevelStatus.tsx
+++ b/src/components/LevelStatus/LevelStatus.tsx
@@ -2,7 +2,7 @@
 
 import LevelProgressBar from '@/components/LevelStatus/LevelProgressBar';
 import { type LevelSystemType } from '@/constants/level';
-import { gradientTextCss } from '@/constants/style/text';
+import { gradientTextCss } from '@/constants/style/gradient';
 import { css, cx } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
 

--- a/src/constants/style/gradient.ts
+++ b/src/constants/style/gradient.ts
@@ -1,0 +1,29 @@
+import { css, cva } from '@/styled-system/css';
+
+export const gradientTextCss = css({
+  animation: 'gradient 3s ease-in-out infinite',
+  backgroundSize: '150% 200%!',
+  backgroundClip: 'text!',
+  background: 'gradients.primary',
+  color: 'transparent',
+});
+
+export const gradientBorderWrapperCss = cva({
+  base: {
+    border: '.5px solid transparent',
+    padding: '0px!', // NOTE: padding 0 필수,
+    backgroundOrigin: 'border-box',
+    backgroundClip: 'content-box, border-box',
+  },
+  variants: {
+    bg: {
+      surface3: {
+        backgroundImage:
+          'linear-gradient(token(colors.bg.surface3), token(colors.bg.surface3)), token(colors.gradients.primary)',
+      },
+    },
+  },
+  defaultVariants: {
+    bg: 'surface3',
+  },
+});

--- a/src/constants/style/text.ts
+++ b/src/constants/style/text.ts
@@ -1,9 +1,0 @@
-import { css } from '@/styled-system/css';
-
-export const gradientTextCss = css({
-  animation: 'gradient 3s ease-in-out infinite',
-  backgroundSize: '150% 200%!',
-  backgroundClip: 'text!',
-  background: 'gradients.primary',
-  color: 'transparent',
-});


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
- lock 되어있는 캐릭터들을 두군데에서 정도 사용하는데, 이를 하나의 컴포넌트로 재사용하고 싶었음. (이후에도 쉽게 추가할 수 있었으면 해서)

<!-- 관련 이슈를 적어주세요 -->
<!-- closed #1-->

## 🎉 변경 사항
- 디자인 시스템에 Banner/CardLevel 이라는 컴포넌트를 구현하고, 이를 재사용해 여러 컴포넌트를 구현
- CardLevel 스토리북에 추가
- Locked Character 리팩토링 (화면 유지)
- gradient border css 구현, cva로 만들어 bg를 선택할수 있도록 구현