### PR TITLE
fix : Thumbnail.tsx image url null 처리 복구

### DIFF
--- a/src/components/Thumbnail/Thumbnail.tsx
+++ b/src/components/Thumbnail/Thumbnail.tsx
@@ -5,8 +5,7 @@ import { cva } from '@/styled-system/css';
 const DEFAULT_THUMBNAIL_URL = '/images/thumbnail-null.png';
 
 function Thumbnail({ url, ...props }: ThumbnailProps) {
-  // const imageUrl = url ?? DEFAULT_THUMBNAIL_URL;
-  const imageUrl = DEFAULT_THUMBNAIL_URL;
+  const imageUrl = url ?? DEFAULT_THUMBNAIL_URL;
 
   switch (props.variant) {
     case 'filled':


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
썸네일 url이 서버 에러 대응으로 null로 바꿔서 보여주던 이슈 변경합니다 

## 🎉 변경 사항

### 🙏 여기는 꼭 봐주세요!

### 사용 방법

## 🌄 스크린샷

## 📚 참고
