### PR TITLE
[Fix] 중복확인 버튼 위치 수정

### DIFF
--- a/src/components/Input/NormalButtonInput.tsx
+++ b/src/components/Input/NormalButtonInput.tsx
@@ -119,6 +119,7 @@ const asterisk = css({
 
 const inputCss = css({
   flex: 1,
+  width: '100%',
   height: '22px',
   textStyle: 'subtitle3',
   color: 'text.secondary',


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?



## 🎉 변경 사항
- NormalButtonInput.tsx의 width를 변경했습니다.
### 🙏 여기는 꼭 봐주세요!
- normal-button을 사용하는 닉네임 설정 페이지도 같이 수정됐습니다.

### 사용 방법

## 🌄 스크린샷
**As-is**
<img width="248" alt="image" src="https://github.com/depromeet/10mm-client-web/assets/67476544/7610e595-b884-45f2-844e-71cde37917a9">
<img width="242" alt="image" src="https://github.com/depromeet/10mm-client-web/assets/67476544/f5b39bd9-aafe-435e-8041-1e6df80cab65">

**To-be**
<img width="267" alt="image" src="https://github.com/depromeet/10mm-client-web/assets/67476544/8accd953-87d1-4e66-9359-564a61dfb8b7">
<img width="267" alt="image" src="https://github.com/depromeet/10mm-client-web/assets/67476544/e324e954-cd60-4f9b-ba43-96e9f8ac4e85">



## 📚 참고
