### PR TITLE
fix : 이미지의 확장자를 서버에서 받아온 데이터로 보내준다

### DIFF
--- a/src/apis/member.ts
+++ b/src/apis/member.ts
@@ -78,13 +78,6 @@ const MEMBER_API = {
   },
 };
 
-export const useCheckUsername = (option?: UseMutationOptions<unknown, unknown, CheckUsernameRequest>) => {
-  return useMutation({
-    mutationFn: MEMBER_API.checkUsername,
-    ...option,
-  });
-};
-
 export const useCheckNickname = (option?: UseMutationOptions<unknown, unknown, CheckNicknameRequest>) => {
   return useMutation({
     mutationFn: MEMBER_API.checkNickname,

--- a/src/apis/schema/member.ts
+++ b/src/apis/schema/member.ts
@@ -10,8 +10,15 @@ export interface MemberType {
   name: string;
   nickname: string;
   profileImageUrl?: string;
+  imageFileExtension: FileExtension;
   memberStatus: string;
   memberRole: string;
   memberVisibility: string;
   username: string;
+}
+
+export enum FileExtension {
+  JPEG = 'JPEG',
+  JPG = 'JPG',
+  PNG = 'PNG',
 }

--- a/src/app/mypage/profile_modify/page.tsx
+++ b/src/app/mypage/profile_modify/page.tsx
@@ -11,7 +11,7 @@ import LoadingSpinner from '@/components/Loading/LoadingSpinner';
 import { useSnackBar } from '@/components/SnackBar/SnackBarProvider';
 import Thumbnail from '@/components/Thumbnail/Thumbnail';
 import { ROUTER } from '@/constants/router';
-import { checkImageType, getUrlImageType, useImage } from '@/hooks/useImage';
+import { checkImageType, useImage } from '@/hooks/useImage';
 import useModal from '@/hooks/useModal';
 import useNickname from '@/hooks/useNickname';
 import { css } from '@/styled-system/css';
@@ -93,7 +93,7 @@ function ProfileModifyPage() {
   };
 
   const onSubmit = async () => {
-    const imageType = imageFile?.type || getUrlImageType(data?.profileImageUrl || '');
+    const imageType = imageFile?.type;
     const imageFileExtension = checkImageType(imageType);
 
     try {
@@ -102,7 +102,7 @@ function ProfileModifyPage() {
           imageFileExtension,
         }));
       await uploadProfileCompleteMutate({
-        imageFileExtension: imageFileExtension ? imageFileExtension : undefined,
+        imageFileExtension: imageFileExtension ? imageFileExtension : data?.imageFileExtension,
         nickname: nickname,
       });
     } catch (e) {

--- a/src/hooks/useImage.ts
+++ b/src/hooks/useImage.ts
@@ -3,15 +3,6 @@ import RECORD_API from '@/apis/record';
 import { IMAGE_File_Extension, type ImageFileExtensionType } from '@/apis/schema/upload';
 import axios from 'axios';
 
-// TODO : 추후 백엔드에서 내려오는 데이터로 변경
-export const getUrlImageType = (url?: string) => {
-  if (!url) return '';
-  console.log(url);
-  const imageType = url.split('/').pop();
-  if (!imageType) return '';
-  return imageType.split('?')[0].replace('.', '/');
-};
-
 export const useImage = (initialImagePreviewUrl?: string) => {
   const [imagePreview, setImagePreview] = useState<string | null>(initialImagePreviewUrl ?? null);
   const imageFile = useRef<File>();


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
마이페이지 이미지 수정시 이미지 파일 확장자를 url에서 파싱해서 보내는게 아닌 서버에서 명시적으로 보낸 데이터로 수정한다

관련 슬랙 : https://depromeet14th.slack.com/archives/C06C1271G56/p1706229449971729
## 🎉 변경 사항

### 🙏 여기는 꼭 봐주세요!

### 사용 방법

## 🌄 스크린샷

## 📚 참고
