### PR TITLE
fix : pushstate props null 대신 빈객체로 변경

### DIFF
--- a/src/app/mission/[id]/stopwatch/index.hooks.ts
+++ b/src/app/mission/[id]/stopwatch/index.hooks.ts
@@ -50,7 +50,7 @@ export function useCustomBack(customBack: () => void) {
   useEffect(() => {
     const backAction = () => browserPreventEvent(customBack);
 
-    history.pushState(null, '', location.href);
+    history.pushState({}, '', location.href);
     window.addEventListener('popstate', backAction);
     return () => {
       window.removeEventListener('popstate', backAction);

--- a/src/app/mission/[id]/stopwatch/page.tsx
+++ b/src/app/mission/[id]/stopwatch/page.tsx
@@ -173,7 +173,7 @@ export default function StopwatchPage() {
 
   const onBackMidModalClose = () => {
     closeBackMidOutModal();
-    history.pushState(null, '', location.href);
+    history.pushState({}, '', location.href);
     onNextStep(prevStep);
   };
 


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
관련 슬랙 : https://depromeet14th.slack.com/archives/C06C1271G56/p1706453020931209
<!-- 관련 이슈를 적어주세요 -->
<!-- closed #1-->

## 🎉 변경 사항
안드로이드 웹뷰에서  history.pushState(null, '', location.href); 로직이 적용되지 않아서 hotfix 합니다

### 🙏 여기는 꼭 봐주세요!
제가 이해한게 맞는지 한번 체크해주세요 @sumi-0011 

### 사용 방법

## 🌄 스크린샷

## 📚 참고
