### PR TITLE
[Hotfix] 스톱워치 페이지에서 그라데이션이 잘리는 문제 수정

### DIFF
--- a/src/app/guest/mission/stopwatch/page.tsx
+++ b/src/app/guest/mission/stopwatch/page.tsx
@@ -72,7 +72,7 @@ export default function GuestMissionStopwatchPage() {
       <p className={titleCss}>{stepLabel.title}</p>
       <p className={descCss}>{stepLabel.desc}</p>
 
-      <section className={stopwatchCss}>
+      <section>
         <Stopwatch
           minutes={minutes}
           seconds={seconds}
@@ -147,14 +147,6 @@ const containerCss = css({
 
 const titleCss = css({ color: 'text.primary', textStyle: 'title2' });
 const descCss = css({ color: 'text.secondary', textStyle: 'body4', marginTop: '4px', marginBottom: '96px' });
-
-const stopwatchCss = css({
-  width: 'fit-content',
-  margin: '0 auto',
-  overflow: 'hidden',
-  maxWidth: '100vw',
-  padding: '4px', // small circle 잘리지 않게
-});
 
 const buttonContainerCss = css({
   margin: '28px auto',

--- a/src/app/guest/mission/stopwatch/page.tsx
+++ b/src/app/guest/mission/stopwatch/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Fragment } from 'react';
 import { useRouter } from 'next/navigation';
 import Button from '@/components/Button/Button';
 import Dialog from '@/components/Dialog/Dialog';
@@ -70,8 +71,14 @@ export default function GuestMissionStopwatchPage() {
     <div className={containerCss}>
       <Header rightAction="none" />
       <p className={titleCss}>{stepLabel.title}</p>
-      <p className={descCss}>{stepLabel.desc}</p>
-
+      <p className={descCss}>
+        {stepLabel.desc.split('\n').map((text) => (
+          <Fragment key={text}>
+            {text}
+            <br />
+          </Fragment>
+        ))}
+      </p>
       <section>
         <Stopwatch
           minutes={minutes}
@@ -146,7 +153,13 @@ const containerCss = css({
 });
 
 const titleCss = css({ color: 'text.primary', textStyle: 'title2' });
-const descCss = css({ color: 'text.secondary', textStyle: 'body4', marginTop: '4px', marginBottom: '96px' });
+const descCss = css({
+  color: 'text.secondary',
+  textStyle: 'body4',
+  marginTop: '8px',
+  marginBottom: '76px',
+  minHeight: '40px',
+});
 
 const buttonContainerCss = css({
   margin: '28px auto',

--- a/src/app/mission/[id]/stopwatch/page.tsx
+++ b/src/app/mission/[id]/stopwatch/page.tsx
@@ -200,7 +200,7 @@ export default function StopwatchPage() {
             ))}
           </p>
         </section>
-        <section className={cx(stopwatchCss, opacityAnimation)}>
+        <section className={opacityAnimation}>
           <Stopwatch
             minutes={minutes}
             seconds={seconds}
@@ -281,14 +281,6 @@ const descCss = css({
   marginTop: '8px',
   marginBottom: '76px',
   minHeight: '40px',
-});
-
-const stopwatchCss = css({
-  width: 'fit-content',
-  margin: '0 auto',
-  overflow: 'hidden',
-  maxWidth: '100vw',
-  padding: '4px', // small circle 잘리지 않게
 });
 
 const buttonContainerCss = css({

--- a/src/app/mission/[id]/stopwatch/page.tsx
+++ b/src/app/mission/[id]/stopwatch/page.tsx
@@ -191,7 +191,7 @@ export default function StopwatchPage() {
       <div className={containerCss}>
         <section key={step} className={opacityAnimation}>
           <h1 className={cx(titleCss)}>{stepLabel.title}</h1>
-          <p className={cx(descCss)}>
+          <p className={descCss}>
             {stepLabel.desc.split('\n').map((text) => (
               <Fragment key={text}>
                 {text}

--- a/src/app/profile/[id]/ProfileContent.tsx
+++ b/src/app/profile/[id]/ProfileContent.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link';
 import Banner from '@/components/Banner/Banner';
 import Thumbnail from '@/components/Thumbnail/Thumbnail';
 import { ROUTER } from '@/constants/router';
-import { getLevel } from '@/utils/result';
 import { css } from '@styled-system/css';
 
 interface ProfileContentProps {
@@ -24,7 +23,6 @@ function ProfileContent({
   rightElement,
   children,
 }: PropsWithChildren<ProfileContentProps>) {
-  const currentLevel = getLevel(symbolStack);
   return (
     <div className={containerCss}>
       <section className={myTabContainerCss}>
@@ -41,13 +39,7 @@ function ProfileContent({
           {rightElement}
         </div>
         <Link href={ROUTER.LEVEL.GUIDE}>
-          <Banner
-            type="level"
-            amount={symbolStack}
-            iconName="alarm"
-            level={currentLevel.label}
-            imageUrl={currentLevel.imageUrl}
-          />
+          <Banner type="level" symbolStack={symbolStack} />
         </Link>
         {children}
         <div className={spaceCss} />

--- a/src/components/Banner/Banner.stories.ts
+++ b/src/components/Banner/Banner.stories.ts
@@ -41,7 +41,7 @@ export const ListBannerDate: Story = {
 export const ListLevelBanner: Story = {
   args: {
     type: 'level',
-    amount: 11,
+    symbolStack: 11,
   },
   argTypes: {},
 };

--- a/src/components/Banner/Banner.stories.ts
+++ b/src/components/Banner/Banner.stories.ts
@@ -38,7 +38,13 @@ export const ListBannerDate: Story = {
   },
   argTypes: {},
 };
-
+export const ListLevelBanner: Story = {
+  args: {
+    type: 'level',
+    amount: 11,
+  },
+  argTypes: {},
+};
 export const CardBanner: Story = {
   args: {
     type: 'card',
@@ -51,6 +57,7 @@ export const CardBanner: Story = {
     date: { table: { disable: true } },
   },
 };
+
 export const GraphicBanner: Story = {
   args: {
     type: 'graphic',

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -50,12 +50,13 @@ export const CardBanner: Story = {
     type: 'card',
     title: '수미칩은 맛있다',
     description: '난 최고야 ',
-    iconUrl: '/assets/icons/clock.png',
+    iconUrl: '/assets/icons/graph/clock.png',
   },
   argTypes: {
     imageUrl: { table: { disable: true } },
     date: { table: { disable: true } },
   },
+  decorators: [(Story) => <div style={{ maxWidth: '167px' }}>{<Story />}</div>],
 };
 
 export const GraphicBanner: Story = {
@@ -67,4 +68,5 @@ export const GraphicBanner: Story = {
     imageUrl: { table: { disable: true } },
     date: { table: { disable: true } },
   },
+  decorators: [(Story) => <div style={{ maxWidth: '235px' }}>{<Story />}</div>],
 };

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
-import { type BannerType } from '@/components/Banner/Banner.types';
-import CardBanner from '@/components/Banner/CardBanner';
-import GraphicBanner from '@/components/Banner/GraphicBanner';
-import ListBanner from '@/components/Banner/ListBanner';
-
-import LevelBanner from './LevelBanner';
+import { type BannerType } from './Banner.types';
+import CardBanner from './CardBanner';
+import GraphicBanner from './GraphicBanner';
+import ListBanner from './ListBanner';
+import ListLevelBanner from './ListLevelBanner';
 
 function Banner(props: BannerType) {
   switch (props.type) {
@@ -15,7 +13,7 @@ function Banner(props: BannerType) {
     case 'graphic':
       return <GraphicBanner {...props} />;
     case 'level':
-      return <LevelBanner {...props} />;
+      return <ListLevelBanner {...props} />;
   }
 }
 

--- a/src/components/Banner/Banner.types.ts
+++ b/src/components/Banner/Banner.types.ts
@@ -23,7 +23,7 @@ export interface GraphicBannerType extends BaseBannerType {
 }
 export interface LevelBannerType extends BaseBannerType {
   type: 'level';
-  amount: number;
+  symbolStack: number;
 }
 
 export type BannerType = ListBannerType | CardBannerType | GraphicBannerType | LevelBannerType;

--- a/src/components/Banner/Banner.types.ts
+++ b/src/components/Banner/Banner.types.ts
@@ -1,5 +1,3 @@
-import { type IconComponentMap } from '@/components/Icon';
-
 interface BaseBannerType {
   type: 'list' | 'card' | 'graphic' | 'level';
 }
@@ -25,9 +23,6 @@ export interface GraphicBannerType extends BaseBannerType {
 }
 export interface LevelBannerType extends BaseBannerType {
   type: 'level';
-  level: string;
-  imageUrl: string;
-  iconName: keyof typeof IconComponentMap;
   amount: number;
 }
 

--- a/src/components/Banner/CardBanner.tsx
+++ b/src/components/Banner/CardBanner.tsx
@@ -5,14 +5,11 @@ import { css } from '@/styled-system/css';
 function CardBanner(props: CardBannerType) {
   return (
     <div className={containerCss}>
-      <div className={innerContainerCss}>
-        <div>
-          <Image src={props.iconUrl} width={20} height={20} alt={props.title} />
-        </div>
-        {/* <Icon name={props.iconName} width={20} height={20} /> */}
-        <p className={descriptionCss}>{props.description}</p>
-        <p className={titleCss}>{props.title}</p>
+      <div>
+        <Image src={props.iconUrl} width={20} height={20} alt={props.title} />
       </div>
+      <p className={descriptionCss}>{props.description}</p>
+      <p className={titleCss}>{props.title}</p>
     </div>
   );
 }
@@ -24,18 +21,13 @@ const containerCss = css({
   width: '100%',
   overflow: 'hidden',
   borderRadius: '22px',
-  boxShadow: '0px 10px 20px 4px rgba(100, 78, 122, 0.20) inset, 0px 4px 20px 0px rgba(16, 15, 23, 0.30)',
-  border: '.3px solid transparent',
-});
-
-const innerContainerCss = css({
+  boxShadow: '0px 10px 30px 4px rgba(78, 80, 122, 0.20) inset, 0px 4px 20px 0px rgba(15, 16, 23, 0.30)',
+  border: ' 1px solid #474A5D',
   padding: '20px 16px 16px',
-  background: 'linear-gradient(136deg, rgba(240, 168, 198, 0.02) 15.95%, rgba(143, 169, 255, 0.02) 85.07%)',
+  background: 'linear-gradient(136deg, rgba(168, 184, 240, 0.02) 15.95%, rgba(165, 143, 255, 0.02) 85.07%)',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  width: '100%',
-  height: '100%',
 });
 
 const descriptionCss = css({
@@ -43,6 +35,7 @@ const descriptionCss = css({
   textStyle: 'body4',
   color: 'text.secondary',
 });
+
 const titleCss = css({
   marginTop: '6px',
   textStyle: 'subtitle1',

--- a/src/components/Banner/GraphicBanner.tsx
+++ b/src/components/Banner/GraphicBanner.tsx
@@ -1,22 +1,22 @@
 import Image from 'next/image';
 import { type GraphicBannerType } from '@/components/Banner/Banner.types';
-import { css } from '@/styled-system/css';
+import { center } from '@/styled-system/patterns';
 
 function GraphicBanner(props: GraphicBannerType) {
   return (
     <div className={containerCss}>
-      <Image src={props.imageUrl} alt="graphicBanner" fill />
+      <Image src={props.imageUrl} alt="graphicBanner" width={160} height={120} />
     </div>
   );
 }
 
 export default GraphicBanner;
 
-const containerCss = css({
+const containerCss = center({
   borderRadius: '22px',
-  border: '0.25px solid #5C5977',
-  background: 'linear-gradient(136deg, rgba(168, 227, 240, 0.02) 15.95%, rgba(143, 169, 255, 0.02) 85.07%)',
-  boxShadow: '-10px 0px 100px 4px rgba(90, 78, 122, 0.20) inset',
+  border: '1px solid #393C4C',
+  background: 'rgba(168, 197, 240, 0.02)',
+  boxShadow: '0px 10px 100px 4px rgba(78, 80, 122, 0.20) inset',
   position: 'relative',
   width: '100%',
   height: '120px',
@@ -25,5 +25,6 @@ const containerCss = css({
   '& img': {
     objectFit: 'contain',
     height: '100%',
+    flex: 0,
   },
 });

--- a/src/components/Banner/ListBanner.tsx
+++ b/src/components/Banner/ListBanner.tsx
@@ -4,11 +4,11 @@ import { css } from '@/styled-system/css';
 
 function ListBanner(props: ListBannerType) {
   return (
-    <div className={missionHistoryBannerCss}>
+    <div className={containerCss}>
       <Image className={imageCss} width={30} height={30} alt={props.title} src={props.imageUrl} />
       <div>
-        <p className={bannerTitleCss}>{props.title}</p>
-        <p className={bannerDescriptionCss}>{props.description}</p>
+        <p className={titleCss}>{props.title}</p>
+        <p className={descriptionCss}>{props.description}</p>
         {props.date && <p className={dateCss}>{props.date}</p>}
       </div>
     </div>
@@ -17,16 +17,16 @@ function ListBanner(props: ListBannerType) {
 
 export default ListBanner;
 
-const missionHistoryBannerCss = css({
+const containerCss = css({
   display: 'flex',
   flexDirection: 'row',
   padding: '16px',
   alignItems: 'center',
   gap: '8px',
   borderRadius: '22px',
-  background: 'linear-gradient(93deg, rgba(25, 23, 27, 0.80) 0.82%, rgba(24, 25, 33, 0.80) 99.97%)',
-  boxShadow: '0px 5px 50px 4px rgba(92, 78, 122, 0.50) inset, 0px 4px 20px 0px rgba(16, 15, 23, 0.20)',
-  backdropFilter: 'blur(20px)',
+  border: '1px solid #22242F',
+  background: 'rgba(181, 184, 255, 0.02)',
+  boxShadow: '-10px 0px 100px 4px rgba(93, 96, 178, 0.10) inset',
 });
 
 const imageCss = css({
@@ -35,13 +35,13 @@ const imageCss = css({
   height: '30px',
 });
 
-const bannerTitleCss = css({
+const titleCss = css({
   textStyle: 'body1',
   color: 'text.primary',
 });
 
-const bannerDescriptionCss = css({
-  textStyle: 'body4',
+const descriptionCss = css({
+  textStyle: 'body5',
   color: 'text.tertiary',
   marginTop: '2px',
 });

--- a/src/components/Banner/ListLevelBanner.tsx
+++ b/src/components/Banner/ListLevelBanner.tsx
@@ -7,7 +7,7 @@ import { getLevel } from '@/utils/result';
 import { type LevelBannerType } from './Banner.types';
 
 function ListLevelBanner(props: LevelBannerType) {
-  const levelInfo = getLevel(props.amount);
+  const levelInfo = getLevel(props.symbolStack);
 
   return (
     <div className={levelBannerCss}>
@@ -17,7 +17,7 @@ function ListLevelBanner(props: LevelBannerType) {
 
       <div className={levelStatusCss}>
         <Icon name={'10mm-symbol-circle'} color={'icon.secondary'} width={12} height={12} />
-        <span className={levelAmountCss}>{props.amount}</span>
+        <span className={levelAmountCss}>{props.symbolStack}</span>
         <Icon name={'arrow-forward'} color={'icon.secondary'} width={14} height={14} />
       </div>
     </div>

--- a/src/components/Banner/ListLevelBanner.tsx
+++ b/src/components/Banner/ListLevelBanner.tsx
@@ -1,6 +1,5 @@
 import Image from 'next/image';
 import Icon from '@/components/Icon';
-import { LEVEL_SYSTEM } from '@/constants/level';
 import { css } from '@/styled-system/css';
 import { getLevel } from '@/utils/result';
 
@@ -29,10 +28,9 @@ export default ListLevelBanner;
 const levelBannerCss = css({
   display: 'flex',
   flexDirection: 'row',
-  padding: '12px 16px',
+  padding: '12px 16px 12px 8px',
   alignItems: 'center',
   marginTop: '20px',
-  gap: '8px',
   borderRadius: '20px',
   background: 'linear-gradient(93deg, rgba(28, 29, 33, 0.80) 0.82%, rgba(24, 25, 33, 0.80) 99.97%)',
   boxShadow: '0px 5px 50px 4px rgba(78, 85, 122, 0.50) inset, 0px 4px 20px 0px rgba(16, 15, 23, 0.20)',
@@ -41,9 +39,10 @@ const levelBannerCss = css({
 
 const imageCss = css({
   flexShrink: '0',
-  width: '36px',
-  height: '36px',
+  width: '53.333px',
+  height: '40px',
   objectFit: 'contain',
+  marginRight: '2px',
 });
 
 const levelCss = css({

--- a/src/components/Banner/ListLevelBanner.tsx
+++ b/src/components/Banner/ListLevelBanner.tsx
@@ -1,24 +1,31 @@
 import Image from 'next/image';
+import Icon from '@/components/Icon';
+import { LEVEL_SYSTEM } from '@/constants/level';
 import { css } from '@/styled-system/css';
+import { getLevel } from '@/utils/result';
 
-import Icon from '../Icon';
 import { type LevelBannerType } from './Banner.types';
 
-export default function LevelBanner(props: LevelBannerType) {
+function ListLevelBanner(props: LevelBannerType) {
+  const levelInfo = getLevel(props.amount);
+
   return (
     <div className={levelBannerCss}>
-      <Image className={imageCss} width={53.333} height={40} alt={props.level} src={props.imageUrl} />
+      <Image className={imageCss} width={53.333} height={40} alt={String(levelInfo.level)} src={levelInfo.imageUrl} />
 
-      <p className={levelCss}>{props.level}</p>
+      <p className={levelCss}>{levelInfo.label}</p>
 
       <div className={levelStatusCss}>
         <Icon name={'10mm-symbol-circle'} color={'icon.secondary'} width={12} height={12} />
-        <span className={levelAmoutCss}>{props.amount}</span>
+        <span className={levelAmountCss}>{props.amount}</span>
         <Icon name={'arrow-forward'} color={'icon.secondary'} width={14} height={14} />
       </div>
     </div>
   );
 }
+
+export default ListLevelBanner;
+
 const levelBannerCss = css({
   display: 'flex',
   flexDirection: 'row',
@@ -27,27 +34,31 @@ const levelBannerCss = css({
   marginTop: '20px',
   gap: '8px',
   borderRadius: '20px',
-  background: 'linear-gradient(93deg, rgba(23, 25, 27, 0.80) 0.82%, rgba(24, 25, 33, 0.80) 99.97%)',
+  background: 'linear-gradient(93deg, rgba(28, 29, 33, 0.80) 0.82%, rgba(24, 25, 33, 0.80) 99.97%)',
   boxShadow: '0px 5px 50px 4px rgba(78, 85, 122, 0.50) inset, 0px 4px 20px 0px rgba(16, 15, 23, 0.20)',
   backdropFilter: 'blur(20px)',
 });
+
 const imageCss = css({
   flexShrink: '0',
   width: '36px',
   height: '36px',
   objectFit: 'contain',
 });
+
 const levelCss = css({
   textStyle: 'body1',
   color: 'text.secondary',
   flex: '1',
 });
+
 const levelStatusCss = css({
   display: 'flex',
   alignItems: 'center',
   gap: '4px',
 });
-const levelAmoutCss = css({
+
+const levelAmountCss = css({
   textStyle: 'subtitle4',
   color: 'purple.purple800',
   fontWeight: 'semibold',

--- a/src/components/Stopwatch/Stopwatch.tsx
+++ b/src/components/Stopwatch/Stopwatch.tsx
@@ -1,5 +1,5 @@
-import Image from 'next/image';
 import Icon from '@/components/Icon';
+import StopwatchContainer from '@/components/Stopwatch/StopwatchContainer';
 import { css } from '@/styled-system/css';
 
 interface Props {
@@ -14,28 +14,7 @@ interface Props {
 function Stopwatch({ minutes, seconds, missionName, stepper, isDisabled, isProgress }: Props) {
   return (
     <div className={containerCss}>
-      <div
-        className={css(imageWrapperCss, {
-          animationPlayState: isProgress ? '' : 'paused',
-          boxShadow: isDisabled
-            ? '0px 4px 40px 4px rgba(60, 58, 75, 0.80) inset, 10px 10px 100px 0px rgba(160, 161, 188, 0.07)'
-            : '0px 4px 40px 4px rgba(100, 78, 122, 0.80) inset, 10px 10px 100px 0px rgba(151, 155, 255, 0.07)',
-        })}
-      >
-        <Image
-          fill
-          src={isDisabled ? '/assets/stopwatch/disabled-circle.png' : '/assets/stopwatch/gradient-circle.png'}
-          alt="stopwatch circle bg"
-          className={css(birCircleImageCss)}
-        />
-        <Image
-          className={smallCircleCss}
-          width={24}
-          height={24}
-          src={isDisabled ? '/assets/stopwatch/disabled-small-circle.svg' : '/assets/stopwatch/small-circle.svg'}
-          alt="small circle"
-        />
-      </div>
+      <StopwatchContainer isPaused={!isProgress} />
       <div className={innerContainerCss}>
         <p
           className={css(categoryCss, ellipsis, {
@@ -91,6 +70,7 @@ const containerCss = css({
   height: '312px',
   borderRadius: '312px',
   color: 'white',
+  margin: 'auto',
 });
 
 const innerContainerCss = css({
@@ -134,33 +114,5 @@ const timeTextCss = {
 };
 
 const lightingWrapperCss = css({ display: 'flex', gap: '5px', marginTop: '12px' });
-
-// background image
-const imageWrapperCss = {
-  position: 'absolute',
-  width: '100%',
-  height: '100%',
-  borderRadius: '312px',
-  top: 0,
-  left: 0,
-  right: 0,
-  bottom: 0,
-  zIndex: 0,
-
-  transition: '1s ease-in-out',
-  // rotate animation
-  transformOrigin: '50% 50%',
-  animation: 'circleRotate 60s linear infinite',
-};
-
-const smallCircleCss = css({ position: 'absolute', top: '-10px', left: 0, right: 0, margin: '0 auto' });
-
-const birCircleImageCss = {
-  position: 'absolute',
-  top: 0,
-  left: 0,
-  right: 0,
-  bottom: 0,
-};
 
 export default Stopwatch;

--- a/src/components/Stopwatch/StopwatchContainer.tsx
+++ b/src/components/Stopwatch/StopwatchContainer.tsx
@@ -1,0 +1,109 @@
+import { css, cx } from '@/styled-system/css';
+
+function StopwatchContainer({ isPaused }: { isPaused?: boolean }) {
+  const animationCss = css({
+    animationPlayState: isPaused ? 'paused !' : '',
+  });
+  return (
+    <div>
+      <div className={cx(positionCss, rotateLayerContainerCss)}>
+        <div className={cx(animationCss, smallCircleLayerCss)}>
+          <div className={cx(smallCircleCss)} />
+        </div>
+        <div className={cx(isPaused ? pauseBorderLayerCss : borderLayerCss, animationCss)}></div>
+      </div>
+      <div className={cx(outerBoxShadowLayerCss, positionCss)}></div>
+      <div className={cx(innerBoxShadowLayerCss, positionCss)}></div>
+    </div>
+  );
+}
+
+export default StopwatchContainer;
+
+const positionCss = css({
+  position: 'absolute',
+  top: 0,
+  bottom: 0,
+  left: 0,
+  right: 0,
+  margin: 0,
+  width: '312px',
+  height: '312px',
+  borderRadius: '312px',
+});
+
+const rotateLayerContainerCss = css({
+  width: '312px',
+  height: '312px',
+  borderRadius: '312px',
+  overflow: 'hidden',
+  padding: '4px',
+  boxSizing: 'content-box',
+  top: '-8px !',
+
+  '& > div': {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    margin: 0,
+    width: '312px',
+    height: '312px',
+    borderRadius: '312px',
+  },
+});
+
+const smallCircleLayerCss = css({
+  zIndex: 5,
+  transition: '.7s ease-in-out',
+  transformOrigin: '50% 50%',
+  animation: 'circleRotate 60s linear infinite',
+});
+
+const smallCircleCss = css({
+  background: '#FAD1FD',
+  filter: 'drop-shadow(0px 0px 6px rgba(255, 255, 255, 0.30))',
+  width: '10px',
+  height: '10px',
+  borderRadius: '10px',
+
+  position: 'absolute',
+  top: '-3px',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  zIndex: 5,
+});
+
+const innerBoxShadowLayerCss = css({
+  border: '4px solid transparent',
+  background: 'linear-gradient(136deg, rgba(240, 168, 198, 0.02) 15.95%, rgba(143, 169, 255, 0.02) 85.07%)',
+  boxShadow: '0px 4px 40px 4px rgba(78, 85, 122, 0.80) inset, 10px 10px 100px 0px rgba(151, 155, 255, 0.07)',
+  zIndex: 2,
+});
+
+const borderLayerCss = css({
+  border: '4px solid transparent',
+  padding: '0px !', // NOTE: padding 0 필수,
+  backgroundOrigin: 'border-box',
+  backgroundClip: 'content-box, border-box',
+  backgroundImage:
+    'linear-gradient(token(colors.bg.surface1), token(colors.bg.surface1)), conic-gradient(#FFC6DB, #EDBCF2,#EDBCF2,#ABDAFD, #9AC2FF,#FFC6DB)',
+  zIndex: 1,
+  transition: '.7s ease-in-out',
+  transformOrigin: '50% 50%',
+  animation: 'circleRotate 60s linear infinite',
+});
+
+const pauseBorderLayerCss = css({
+  border: '4px solid token(colors.gray.gray500) !',
+  backgroundOrigin: 'border-box',
+  backgroundClip: 'content-box, border-box',
+  zIndex: 1,
+});
+
+const outerBoxShadowLayerCss = css({
+  border: '4px solid #2C2F37',
+  boxShadow:
+    '0px 10px 30px 5px rgba(19, 15, 195, 0.07), -10px 10px 20px 5px rgba(215, 114, 114, 0.05), 15px 10px 20px 5px rgba(57, 180, 219, 0.04)',
+  zIndex: 0,
+});


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
closed #430
<!-- 관련 이슈를 적어주세요 -->
<!-- closed #1-->

## 🎉 변경 사항
- 스톱워치 페이지에서 그라데이션이 잘리는 문제를 수정했어요. 
- Banner 컴포넌트 디자인 변경사항을 수정하였어요. 

### 🙏 여기는 꼭 봐주세요!

스톱워치 페이지에서 그라데이션이 잘리는 문제는, 
스톱워치 컴포넌트를 감싸는 wrapper에서 overflow hidden을 해주고 있어 box-shadow 가 잘리는 문제였어요. 

overflow hidden을 걸어준 이유 는 아래 스크린샷에서 확인할 수 있는데요, 
![Jan-29-2024 00-57-27](https://github.com/depromeet/10mm-client-web/assets/49177223/432a3542-5d4c-42f2-8eac-30fb5b71367a)

위와 같이 사진을 animation rotate로 돌리는데, 사진이 돌아가면서 화면에 넘치는 문제가 있었어요. 
화면에 넘쳐서 스크롤이 생기거나, 모바일에서는 옆에 흰 공간이 생기는 버그가 있었습니다. 
이 버그를 핫 픽스하면서 overflow:hidden을 걸어주었는데, box-shadow의 범위가 넓다보니 잘리는 문제가 생긴것이죠. 

기존에는 그라데이션 사진을 추출받아 사용하였는데, 이 방법을 사용하니 잘리는 문제를 해결하기가 어려웠어요, 
그래서 **그라데이션과 box-shadow 등등을 아예 css로 추가하는 방법**을 사용했습니다. (레이어 분리를 @지우 언니가 도와주었어요)

돌아가야하는 레이어에만 rotate animation을 걸고, 돌아가는 레이어 위에 한 겹을 감싸 overflow:hidden을 걸어주어 화면에 넘치지 않도록 하였어요 
box-shadow의 경우에는 돌아가지 않아도 되어 overflow:hidden을 걸어주지 않아도 되었습니다. 

css로 구현한 그라데이션 border가 조금 쨍한가? 🤔 싶었는데 다들 괜찮아 보이신다고 하네요 
이상해보이면 @지우 언니가 그때 이야기 해주신다고 하셨습니당. 


## 🌄 스크린샷
![IMG_5807](https://github.com/depromeet/10mm-client-web/assets/49177223/b1405485-2779-4a6d-bd8e-b1ab71138852)

## 📚 참고
