### PR TITLE
제니퍼 프론트 모니터링 툴 추가

### DIFF
--- a/src/components/MonitoringInitializer.tsx
+++ b/src/components/MonitoringInitializer.tsx
@@ -5,6 +5,7 @@ import { isProd } from '@/utils/common';
 import { eventLogger } from '@/utils/event';
 
 const GA_TRACKING_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS;
+const JENNIFERSOFT_FRONT_ID = process.env.NEXT_PUBLIC_JENNIFERSOFT_FRONT_ID;
 
 const MonitoringInitializer = () => {
   useEffect(() => {
@@ -24,6 +25,15 @@ const MonitoringInitializer = () => {
           gtag('config', '${GA_TRACKING_ID}');
         `}
       </Script>
+      <Script id="jennifersoft-front">
+        {`
+          (function(j,ennifer) {
+            j['dmndata']=[];j['jenniferFront']=function(args){window.dmndata.push(args)};
+            j['dmnaid']=ennifer;j['dmnatime']=new Date();j['dmnanocookie']=false;j['dmnajennifer']='JENNIFER_FRONT@INTG';
+        }(window, '${JENNIFERSOFT_FRONT_ID}'));
+        `}
+      </Script>
+      <Script src={`https://d-collect.jennifersoft.com/${JENNIFERSOFT_FRONT_ID}/demian.js`} />
     </div>
   );
 };


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
- 제니퍼 프론트라는 모니터링 툴을 부착했어요.  (무료임)
- 세부 설정은 이후에 할 예정입니다 

저희 팀 구글 계정으로 
https://front.jennifersoft.com/#/app/206ba114/dashboard/overview?dateFilterType=hour&hourFilter=3600 이 페이지를 들어가면 대시보드를 확인하 실 수 있어요. 

로컬에서는 테스트 완료하였답니다. 👍

## 🌄 스크린샷
<img width="1787" alt="image" src="https://github.com/depromeet/10mm-client-web/assets/49177223/a2d80eed-8724-4e2c-8a33-f0c8ed539c12">

## 📚 참고
- https://vroomfan.tistory.com/47