### PR TITLE
[Fix] 미션캘린더 뷰에서 오늘 이후의 날짜는 라우팅 되지 않는다

### DIFF
--- a/src/app/mission/[id]/detail/MissionCalender/MissionCalendar.utils.ts
+++ b/src/app/mission/[id]/detail/MissionCalender/MissionCalendar.utils.ts
@@ -64,22 +64,23 @@ export const getMissionCalendarItemProps = (
   records: RecordType[],
   isFollow?: boolean,
 ) => {
-  console.log({ missionStartAt, day });
   const isMissionStarted =
-    dayjs(missionStartAt.split(' ')[0]).isBefore(dayjs(`${day.year}-${day.month}-${day.date}`)) ||
-    dayjs(missionStartAt.split(' ')[0]).isSame(dayjs(`${day.year}-${day.month}-${day.date}`));
+    dayjs(missionStartAt).isBefore(dayjs(`${day.year}-${day.month}-${day.date}`), 'day') ||
+    dayjs(missionStartAt).isSame(dayjs(`${day.year}-${day.month}-${day.date}`), 'day');
+
   const filterRecord = records.filter((record) => record.missionDay === day.date);
-  console.log({
-    isMissionStarted,
-    filterRecord,
-    missionStartAt,
-  });
-  if (!isMissionStarted) {
+
+  const isDayBeforeToday =
+    dayjs(`${day.year}-${day.month}-${day.date}`).isBefore(dayjs(), 'day') ||
+    dayjs().isSame(dayjs(`${day.year}-${day.month}-${day.date}`), 'day');
+
+  if (!isMissionStarted || !isDayBeforeToday) {
     return {
       routerLink: '',
       imageUrl: undefined,
     };
   }
+
   if (filterRecord.length > 0) {
     return {
       routerLink: isFollow


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
closed #443

## 🎉 변경 사항
- 미션 캘린더뷰 라우팅 수정
- 닉네임 trim() 설정 [b26312b](https://github.com/depromeet/10mm-client-web/pull/442/commits/b26312b0744ddfe32da9c58a45d5ae45b6b6f50a)
(이거는 이미 devlop 에 머지 되었는데 혼선을 막기위해 여기에 기록합니다)

### 🙏 여기는 꼭 봐주세요!

### 사용 방법

## 🌄 스크린샷

https://github.com/depromeet/10mm-client-web/assets/68339352/0d8b9694-ba16-45b4-a028-aa1a305a522c


## 📚 참고
