### PR TITLE
feat: full tab component 생성

### DIFF
--- a/src/components/Tab/FullTab.tsx
+++ b/src/components/Tab/FullTab.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import FullTabParts from '@/components/Tab/FullTabParts';
+import { type TabProps } from '@/components/Tab/Tab.types';
+import { css } from '@/styled-system/css';
+
+function FullTab({ tabs, activeTab, onTabClick }: TabProps) {
+  return (
+    <div className={tabWrapperCss}>
+      {tabs.map((tab) => (
+        <FullTabParts key={tab.id} {...tab} isActive={tab.id === activeTab} onTabClick={() => onTabClick?.(tab)} />
+      ))}
+    </div>
+  );
+}
+
+export default FullTab;
+
+const tabWrapperCss = css({
+  display: 'flex',
+  width: '100%',
+  height: 'fit-content',
+  padding: '0 16px',
+});

--- a/src/components/Tab/FullTabParts.tsx
+++ b/src/components/Tab/FullTabParts.tsx
@@ -1,0 +1,31 @@
+import { type FullTabPartsProps } from '@/components/Tab/Tab.types';
+import { css, cx } from '@/styled-system/css';
+
+function FullTabParts({ tabName, isActive, onTabClick }: FullTabPartsProps) {
+  return (
+    <div
+      className={cx(
+        tabNameCss,
+        css({
+          color: isActive ? 'text.secondary' : 'text.tertiary',
+          borderColor: isActive ? 'icon.secondary' : 'gray.gray150',
+        }),
+      )}
+      onClick={onTabClick}
+    >
+      {tabName}
+    </div>
+  );
+}
+
+export default FullTabParts;
+
+const tabNameCss = css({
+  textStyle: 'subtitle4',
+  borderBottomWidth: '1px',
+  cursor: 'pointer',
+  flex: 1,
+  lineHeight: '55px',
+  textAlign: 'center',
+  transition: 'color 0.3s, border-color 0.3s',
+});

--- a/src/components/Tab/Tab.stories.tsx
+++ b/src/components/Tab/Tab.stories.tsx
@@ -1,4 +1,5 @@
 import { type ComponentProps } from 'react';
+import FullTab from '@/components/Tab/FullTab';
 import Tab from '@/components/Tab/Tab';
 import { useTab } from '@/components/Tab/Tab.hooks';
 import type { Meta, StoryObj } from '@storybook/react';
@@ -58,4 +59,19 @@ export const ActiveTab = () => {
   ]);
 
   return <Tab {...props} />;
+};
+
+export const ActiveFullTab = () => {
+  const props = useTab([
+    {
+      id: 'Tab1',
+      tabName: 'Tab1',
+    },
+    {
+      id: 'Tab2',
+      tabName: 'Tab2',
+    },
+  ]);
+
+  return <FullTab {...props} />;
 };

--- a/src/components/Tab/Tab.types.ts
+++ b/src/components/Tab/Tab.types.ts
@@ -13,3 +13,8 @@ export interface TabPartsProps extends TabType {
   isActive: boolean;
   onTabClick?: (clickedTabType: TabType) => void;
 }
+
+export interface FullTabPartsProps extends TabPartsProps {
+  isActive: boolean;
+  onTabClick?: () => void;
+}


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
- 팔로우/팔로잉 페이지에서 사용되는 FullTabComponent를 구현하였어요.
- 기존에 있는 Tab컴포넌트의 로직을 재사용하였습니다. 

## 🌄 스크린샷
<img width="375" alt="image" src="https://github.com/depromeet/10mm-client-web/assets/49177223/2154c231-f7b4-43ea-99ac-aad870864191">

## 📚 참고
