### PR TITLE
[FEAT] 이전 달의 미션 캘린더 정보를 볼 수 있다. 

### DIFF
--- a/src/app/mission/[id]/detail/MissionCalender/MissionCalendar.tsx
+++ b/src/app/mission/[id]/detail/MissionCalender/MissionCalendar.tsx
@@ -12,22 +12,25 @@ import { css } from '@styled-system/css';
 import dayjs, { type Dayjs } from 'dayjs';
 
 function MissionCalendar({
-  initialDate,
+  currentData,
   missionId,
   isFollow,
 }: {
-  initialDate: Dayjs;
+  currentData: Dayjs;
   missionId: number;
   isFollow?: boolean;
 }) {
-  const { currentDate, monthCalendarData, onPrevMonth, onNextMonth, isCurrentMonth } = useCalendar(initialDate);
+  const { date, monthCalendarData, onPrevMonth, onNextMonth, isCurrentMonth } = useCalendar({
+    currentData,
+    isQueryParams: true,
+  });
 
-  const currentYear = currentDate.year();
-  const currentMonth = currentDate.month() + 1;
+  const currentYear = date.year();
+  const currentMonth = date.month() + 1;
 
   const { data } = useGetRecord({
     missionId,
-    yearMonth: getYearMonth(currentDate),
+    yearMonth: getYearMonth(date),
   });
   const missionStartedAt = data?.missionStartedAt || '';
 

--- a/src/app/mission/[id]/detail/MissionCalender/MissionCalendar.tsx
+++ b/src/app/mission/[id]/detail/MissionCalender/MissionCalendar.tsx
@@ -8,19 +8,20 @@ import {
 } from '@/app/mission/[id]/detail/MissionCalender/MissionCalendar.utils';
 import MissionCalendarItem from '@/app/mission/[id]/detail/MissionCalender/MissionCalendarItem';
 import { css } from '@styled-system/css';
+import { type Dayjs } from 'dayjs';
 
 function MissionCalendar({
   currentDate,
   missionId,
   isFollow,
 }: {
-  currentDate: Date;
+  currentDate: Dayjs;
   missionId: number;
   isFollow?: boolean;
 }) {
-  const currentYear = currentDate.getFullYear();
-  const currentMonth = currentDate.getMonth() + 1;
-  const selectedDate = currentDate.getDate();
+  const currentYear = currentDate.year();
+  const currentMonth = currentDate.month() + 1;
+  const selectedDate = currentDate.date();
 
   const { monthCalendarData } = getCalenderInfo(currentMonth, currentYear);
   const { data } = useGetRecord({

--- a/src/app/mission/[id]/detail/MissionCalender/MissionCalendar.tsx
+++ b/src/app/mission/[id]/detail/MissionCalender/MissionCalendar.tsx
@@ -2,28 +2,29 @@ import Link from 'next/link';
 import { useGetRecord } from '@/apis';
 import { WEEK_DAYS } from '@/app/mission/[id]/detail/MissionCalender/MissionCalendar.constants';
 import {
-  getCalenderInfo,
   getMissionCalendarItemProps,
   getYearMonth,
 } from '@/app/mission/[id]/detail/MissionCalender/MissionCalendar.utils';
 import MissionCalendarItem from '@/app/mission/[id]/detail/MissionCalender/MissionCalendarItem';
+import Icon from '@/components/Icon';
+import useCalendar from '@/hooks/useCalendar';
 import { css } from '@styled-system/css';
-import { type Dayjs } from 'dayjs';
+import dayjs, { type Dayjs } from 'dayjs';
 
 function MissionCalendar({
-  currentDate,
+  initialDate,
   missionId,
   isFollow,
 }: {
-  currentDate: Dayjs;
+  initialDate: Dayjs;
   missionId: number;
   isFollow?: boolean;
 }) {
+  const { currentDate, monthCalendarData, onPrevMonth, onNextMonth, isCurrentMonth } = useCalendar(initialDate);
+
   const currentYear = currentDate.year();
   const currentMonth = currentDate.month() + 1;
-  const selectedDate = currentDate.date();
 
-  const { monthCalendarData } = getCalenderInfo(currentMonth, currentYear);
   const { data } = useGetRecord({
     missionId,
     yearMonth: getYearMonth(currentDate),
@@ -32,8 +33,24 @@ function MissionCalendar({
 
   return (
     <section>
-      <div className={missionHistoryCalendarCss}>
-        {currentYear}년 {currentMonth}월
+      <div
+        className={css({
+          display: 'flex',
+          alignItems: 'center',
+          gap: '4px',
+        })}
+      >
+        <button type={'button'} className={buttonCss} onClick={onPrevMonth}>
+          <Icon name="arrow-back" size={12} />
+        </button>
+        <div className={missionHistoryCalendarCss}>
+          {currentYear}년 {currentMonth}월
+        </div>
+        {!isCurrentMonth && (
+          <button type={'button'} className={buttonCss} onClick={onNextMonth}>
+            <Icon name="arrow-forward" size={12} />
+          </button>
+        )}
       </div>
       <table className={tableCss}>
         <thead>
@@ -54,14 +71,17 @@ function MissionCalendar({
                   data?.missionRecords || [],
                   isFollow,
                 );
+
+                const isToday = dayjs().isSame(`${day.year}-${day.month}-${day.date}`, 'day');
+
                 return (
                   <td key={`${day.year}-${day.month}-${day.date}`} className={missionCalendarTdCss}>
                     {routerLink ? (
                       <Link href={routerLink}>
-                        <MissionCalendarItem date={day.date} {...restProps} isActive={day.date === selectedDate} />
+                        <MissionCalendarItem date={day.date} {...restProps} isActive={isToday} />
                       </Link>
                     ) : (
-                      <MissionCalendarItem date={day.date} {...restProps} isActive={day.date === selectedDate} />
+                      <MissionCalendarItem date={day.date} {...restProps} isActive={isToday} />
                     )}
                   </td>
                 );
@@ -75,6 +95,10 @@ function MissionCalendar({
 }
 
 export default MissionCalendar;
+
+const buttonCss = css({
+  padding: '8px',
+});
 
 const tableCss = css({
   width: '100%',

--- a/src/app/mission/[id]/detail/MissionCalender/MissionCalendar.utils.ts
+++ b/src/app/mission/[id]/detail/MissionCalender/MissionCalendar.utils.ts
@@ -2,58 +2,6 @@ import { type RecordType } from '@/apis/schema/record';
 import { ROUTER } from '@/constants/router';
 import dayjs, { type Dayjs } from 'dayjs';
 
-const getWeekArray = (totalDate: number, offsetDate: number) => {
-  return Array.from({ length: 7 }, (_, i) => {
-    const currentDate = offsetDate + i;
-    if (currentDate < 0) {
-      return 0;
-    }
-
-    if (currentDate > totalDate) {
-      return 0;
-    }
-    return currentDate;
-  });
-};
-
-const getMonthArray = (prevBlankCount: number, totalDate: number) => {
-  const weekNumber = Math.ceil((prevBlankCount + totalDate) / 7);
-
-  return Array.from({ length: weekNumber }, (_, weekIndex) => {
-    const offsetDate = weekIndex * 7 - prevBlankCount + 1;
-
-    return getWeekArray(totalDate, offsetDate);
-  });
-};
-
-export const getCalenderInfo = (currentMonth: number, currentYear: number) => {
-  // 이번달 1일
-  const firstDate = new Date(currentYear, currentMonth - 1, 1);
-
-  // 이번달 마지막날
-  const lastDate = new Date(currentYear, currentMonth, 0);
-
-  // getDay() : 일요일 0 ~ 토요일 6
-  const prevBlankCount = firstDate.getDay();
-  const totalDate = lastDate.getDate();
-
-  const monthCalendarData = getMonthArray(prevBlankCount, totalDate).map((week) =>
-    week.map((date) => {
-      if (date === 0) {
-        return null;
-      }
-
-      return {
-        year: currentYear,
-        month: currentMonth,
-        date,
-      };
-    }),
-  );
-
-  return { monthCalendarData };
-};
-
 export const getMissionCalendarItemProps = (
   missionStartAt: string,
   day: {

--- a/src/app/mission/[id]/detail/MissionCalender/MissionCalendar.utils.ts
+++ b/src/app/mission/[id]/detail/MissionCalender/MissionCalendar.utils.ts
@@ -1,6 +1,6 @@
 import { type RecordType } from '@/apis/schema/record';
 import { ROUTER } from '@/constants/router';
-import dayjs from 'dayjs';
+import dayjs, { type Dayjs } from 'dayjs';
 
 const getWeekArray = (totalDate: number, offsetDate: number) => {
   return Array.from({ length: 7 }, (_, i) => {
@@ -95,9 +95,9 @@ export const getMissionCalendarItemProps = (
   };
 };
 
-export const getYearMonth = (currentDate: Date) => {
-  const year = currentDate.getFullYear();
-  const month = currentDate.getMonth() + 1;
+export const getYearMonth = (currentDate: Dayjs) => {
+  const year = currentDate.year();
+  const month = currentDate.month() + 1;
   const monthString = month < 10 ? `0${month}` : `${month}`;
   return `${year}-${monthString}`;
 };

--- a/src/app/mission/[id]/detail/MissionHistoryBanner/MissionHistoryBannerApi.tsx
+++ b/src/app/mission/[id]/detail/MissionHistoryBanner/MissionHistoryBannerApi.tsx
@@ -1,9 +1,12 @@
-import { useGetMissionDetail } from '@/apis/mission';
+import { useGetMissionDetailNoSuspense } from '@/apis/mission';
 import MissionHistoryBanner from '@/app/mission/[id]/detail/MissionHistoryBanner/MissionHistoryBanner';
+import MissionHistorySkeleton from '@/app/mission/[id]/detail/MissionHistoryBanner/MissionHistorySkeleton';
 import { MISSION_CATEGORY_LABEL } from '@/constants/mission';
 
 function MissionHistoryBannerApi({ missionId }: { missionId: string }) {
-  const { data } = useGetMissionDetail(missionId);
+  const { data } = useGetMissionDetailNoSuspense(missionId);
+
+  if (!data) return <MissionHistorySkeleton />;
 
   const title = data.name;
   const description = data.content;

--- a/src/app/mission/[id]/detail/MissionHistoryTab.tsx
+++ b/src/app/mission/[id]/detail/MissionHistoryTab.tsx
@@ -1,25 +1,19 @@
-import { Suspense } from 'react';
 import { useParams } from 'next/navigation';
 import MissionCalendar from '@/app/mission/[id]/detail/MissionCalender/MissionCalendar';
 import MissionHistoryBannerApi from '@/app/mission/[id]/detail/MissionHistoryBanner/MissionHistoryBannerApi';
-import MissionHistorySkeleton from '@/app/mission/[id]/detail/MissionHistoryBanner/MissionHistorySkeleton';
 import { css } from '@styled-system/css';
 import dayjs from 'dayjs';
 
 function MissionHistoryTab({ isFollow }: { isFollow?: boolean }) {
   const { id } = useParams();
   const missionId = id as string;
-  const initialDate = dayjs();
+  const currentData = dayjs();
 
   return (
     <div className={scrollAreaCss}>
       <div className={missionHistoryTabCss}>
-        <Suspense fallback={<MissionHistorySkeleton />}>
-          {missionId && <MissionHistoryBannerApi missionId={missionId} />}
-        </Suspense>
-        <Suspense>
-          <MissionCalendar isFollow={isFollow} initialDate={initialDate} missionId={Number(missionId)} />
-        </Suspense>
+        {missionId && <MissionHistoryBannerApi missionId={missionId} />}
+        <MissionCalendar isFollow={isFollow} currentData={currentData} missionId={Number(missionId)} />
       </div>
     </div>
   );

--- a/src/app/mission/[id]/detail/MissionHistoryTab.tsx
+++ b/src/app/mission/[id]/detail/MissionHistoryTab.tsx
@@ -9,7 +9,7 @@ import dayjs from 'dayjs';
 function MissionHistoryTab({ isFollow }: { isFollow?: boolean }) {
   const { id } = useParams();
   const missionId = id as string;
-  const currentDate = dayjs();
+  const initialDate = dayjs();
 
   return (
     <div className={scrollAreaCss}>
@@ -18,7 +18,7 @@ function MissionHistoryTab({ isFollow }: { isFollow?: boolean }) {
           {missionId && <MissionHistoryBannerApi missionId={missionId} />}
         </Suspense>
         <Suspense>
-          <MissionCalendar isFollow={isFollow} currentDate={currentDate} missionId={Number(missionId)} />
+          <MissionCalendar isFollow={isFollow} initialDate={initialDate} missionId={Number(missionId)} />
         </Suspense>
       </div>
     </div>

--- a/src/app/mission/[id]/detail/MissionHistoryTab.tsx
+++ b/src/app/mission/[id]/detail/MissionHistoryTab.tsx
@@ -4,11 +4,12 @@ import MissionCalendar from '@/app/mission/[id]/detail/MissionCalender/MissionCa
 import MissionHistoryBannerApi from '@/app/mission/[id]/detail/MissionHistoryBanner/MissionHistoryBannerApi';
 import MissionHistorySkeleton from '@/app/mission/[id]/detail/MissionHistoryBanner/MissionHistorySkeleton';
 import { css } from '@styled-system/css';
+import dayjs from 'dayjs';
 
 function MissionHistoryTab({ isFollow }: { isFollow?: boolean }) {
   const { id } = useParams();
   const missionId = id as string;
-  const currentDate = new Date();
+  const currentDate = dayjs();
 
   return (
     <div className={scrollAreaCss}>

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -1,21 +1,37 @@
 import { useState } from 'react';
-import { type Dayjs } from 'dayjs';
+import useQueryParams from '@/hooks/useQueryParams';
+import dayjs, { type Dayjs } from 'dayjs';
 
-const useCalendar = (date: Dayjs) => {
-  const [currentDate, setDate] = useState(date);
-  const { monthCalendarData } = getCalenderInfo(currentDate.month() + 1, currentDate.year());
+/**
+ * useCalendar hook - 달력 정보를 다루기 위한 hook
+ *
+ * @param date 초기 랜더링 시 달력의 기준이 되는 날짜
+ * @param isQueryParams 년과 월의 정보를 query params로 관리할지 여부
+ */
+const useCalendar = ({ currentData, isQueryParams }: { currentData: Dayjs; isQueryParams?: boolean }) => {
+  const { queryParams, setQueryParams } = useQueryParams({ queryKey: 'date' });
+  const [date, setDate] = useState(queryParams ? dayjs(queryParams) : currentData);
+  const { monthCalendarData } = getCalenderInfo(date.month() + 1, date.year());
 
   const onNextMonth = () => {
-    setDate(currentDate.add(1, 'month'));
+    const nextMonth = date.add(1, 'month');
+    setDate(nextMonth);
+    if (isQueryParams) {
+      setQueryParams({ date: nextMonth.format('YYYY-MM') });
+    }
   };
 
   const onPrevMonth = () => {
-    setDate(currentDate.subtract(1, 'month'));
+    const prevMonth = date.subtract(1, 'month');
+    setDate(prevMonth);
+    if (isQueryParams) {
+      setQueryParams({ date: prevMonth.format('YYYY-MM') });
+    }
   };
 
-  const isCurrentMonth = date.month() === currentDate.month() && date.year() === currentDate.year();
+  const isCurrentMonth = currentData.month() === date.month() && currentData.year() === date.year();
 
-  return { currentDate, monthCalendarData, onNextMonth, onPrevMonth, isCurrentMonth };
+  return { date, monthCalendarData, onNextMonth, onPrevMonth, isCurrentMonth };
 };
 
 export default useCalendar;

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import { type Dayjs } from 'dayjs';
+
+const useCalendar = (date: Dayjs) => {
+  const [currentDate, setDate] = useState(date);
+  const { monthCalendarData } = getCalenderInfo(currentDate.month() + 1, currentDate.year());
+
+  const onNextMonth = () => {
+    setDate(currentDate.add(1, 'month'));
+  };
+
+  const onPrevMonth = () => {
+    setDate(currentDate.subtract(1, 'month'));
+  };
+
+  const isCurrentMonth = date.month() === currentDate.month() && date.year() === currentDate.year();
+
+  return { currentDate, monthCalendarData, onNextMonth, onPrevMonth, isCurrentMonth };
+};
+
+export default useCalendar;
+
+const getCalenderInfo = (currentMonth: number, currentYear: number) => {
+  // 이번달 1일
+  const firstDate = new Date(currentYear, currentMonth - 1, 1);
+
+  // 이번달 마지막날
+  const lastDate = new Date(currentYear, currentMonth, 0);
+
+  // getDay() : 일요일 0 ~ 토요일 6
+  const prevBlankCount = firstDate.getDay();
+  const totalDate = lastDate.getDate();
+
+  const monthCalendarData = getMonthArray(prevBlankCount, totalDate).map((week) =>
+    week.map((date) => {
+      if (date === 0) {
+        return null;
+      }
+
+      return {
+        year: currentYear,
+        month: currentMonth,
+        date,
+      };
+    }),
+  );
+
+  return { monthCalendarData };
+};
+
+const getMonthArray = (prevBlankCount: number, totalDate: number) => {
+  const weekNumber = Math.ceil((prevBlankCount + totalDate) / 7);
+
+  return Array.from({ length: weekNumber }, (_, weekIndex) => {
+    const offsetDate = weekIndex * 7 - prevBlankCount + 1;
+
+    return getWeekArray(totalDate, offsetDate);
+  });
+};
+
+const getWeekArray = (totalDate: number, offsetDate: number) => {
+  return Array.from({ length: 7 }, (_, i) => {
+    const currentDate = offsetDate + i;
+    if (currentDate < 0) {
+      return 0;
+    }
+
+    if (currentDate > totalDate) {
+      return 0;
+    }
+    return currentDate;
+  });
+};

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import useQueryParams from '@/hooks/useQueryParams';
+import useSearchParamState from '@/hooks/useSearchParamState';
 import dayjs, { type Dayjs } from 'dayjs';
 
 /**
@@ -9,7 +9,7 @@ import dayjs, { type Dayjs } from 'dayjs';
  * @param isQueryParams 년과 월의 정보를 query params로 관리할지 여부
  */
 const useCalendar = ({ currentData, isQueryParams }: { currentData: Dayjs; isQueryParams?: boolean }) => {
-  const { queryParams, setQueryParams } = useQueryParams({ queryKey: 'date' });
+  const { queryParams, setQueryParams } = useSearchParamState({ queryKey: 'date' });
   const [date, setDate] = useState(queryParams ? dayjs(queryParams) : currentData);
   const { monthCalendarData } = getCalenderInfo(date.month() + 1, date.year());
 

--- a/src/hooks/useQueryParams.ts
+++ b/src/hooks/useQueryParams.ts
@@ -1,0 +1,21 @@
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+/**
+ * useQueryParams hook - query params를 다루기 위한 hook
+ * UI 상태를 query params로 관리하기 위한 hook
+ * @param queryKey
+ */
+const useQueryParams = <T extends string>({ queryKey }: { queryKey: T }) => {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const queryParams = searchParams.get(queryKey) as string | undefined;
+
+  const setQueryParamsHandler = (newQueryParams: Record<T, string>) => {
+    router.push(pathname + '?' + new URLSearchParams(newQueryParams).toString());
+  };
+
+  return { queryParams, setQueryParams: setQueryParamsHandler };
+};
+
+export default useQueryParams;

--- a/src/hooks/useQueryParams.ts
+++ b/src/hooks/useQueryParams.ts
@@ -12,7 +12,7 @@ const useQueryParams = <T extends string>({ queryKey }: { queryKey: T }) => {
   const queryParams = searchParams.get(queryKey) as string | undefined;
 
   const setQueryParamsHandler = (newQueryParams: Record<T, string>) => {
-    router.push(pathname + '?' + new URLSearchParams(newQueryParams).toString());
+    router.replace(pathname + '?' + new URLSearchParams(newQueryParams).toString());
   };
 
   return { queryParams, setQueryParams: setQueryParamsHandler };

--- a/src/hooks/useSearchParamState.ts
+++ b/src/hooks/useSearchParamState.ts
@@ -1,11 +1,11 @@
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 /**
- * useQueryParams hook - query params를 다루기 위한 hook
+ * useSearchParamState hook - query params를 다루기 위한 hook
  * UI 상태를 query params로 관리하기 위한 hook
  * @param queryKey
  */
-const useQueryParams = <T extends string>({ queryKey }: { queryKey: T }) => {
+const useSearchParamState = <T extends string>({ queryKey }: { queryKey: T }) => {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
@@ -18,4 +18,4 @@ const useQueryParams = <T extends string>({ queryKey }: { queryKey: T }) => {
   return { queryParams, setQueryParams: setQueryParamsHandler };
 };
 
-export default useQueryParams;
+export default useSearchParamState;


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
closed #468

## 🎉 변경 사항
- useCalendar 훅 구현
- query params 상태를 set 과 get할수 있는 useQueryParams 훅 구현 
 
### 🙏 여기는 꼭 봐주세요!
- 친구 미션 상세 와 내 미션 상세 페이지 캘린더에서 이전 달을 볼 수 있게 변경하였습니다.

### 사용 방법

## 🌄 스크린샷

https://github.com/depromeet/10mm-client-web/assets/68339352/51256bbd-dfd0-49a7-b9e3-b443adc6833b


## 📚 참고

피그마 : https://www.figma.com/file/waOSgkTYJKQdMHXnGPlOum/%5BDEV%5D-Design-Guide?type=design&node-id=4467-55942&mode=design&t=bxPzMOxk49mU79Eu-11

관련 슬랙 : https://depromeet14th.slack.com/archives/C0647U2UG05/p1707054903589829
