### PR TITLE
[Feat] event logging 추가

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -17,6 +17,7 @@ interface LoginRequest {
 interface LoginResponse {
   accessToken: string;
   refreshToken: string;
+  memberId?: number;
 }
 
 interface RegisterRequest {

--- a/src/app/auth/kakaoCallback/page.tsx
+++ b/src/app/auth/kakaoCallback/page.tsx
@@ -29,6 +29,7 @@ export default function KakaoCallbackPage() {
             {
               onSuccess: () => {
                 router.push(ROUTER.HOME);
+                //TODO : 로그인시 이벤트 identifier 필요
               },
             },
           );

--- a/src/app/auth/kakaoCallback/page.tsx
+++ b/src/app/auth/kakaoCallback/page.tsx
@@ -6,6 +6,7 @@ import { useSocialLogin } from '@/apis/auth';
 import Loading from '@/components/Loading';
 import { AUTH_PROVIDER } from '@/constants/common';
 import { ROUTER } from '@/constants/router';
+import { eventLogger } from '@/utils';
 
 export default function KakaoCallbackPage() {
   const router = useRouter();
@@ -27,9 +28,11 @@ export default function KakaoCallbackPage() {
               idToken: data.id_token,
             },
             {
-              onSuccess: () => {
+              onSuccess: (successData) => {
+                if (successData?.memberId) {
+                  eventLogger.identify(successData.memberId.toString());
+                }
                 router.push(ROUTER.HOME);
-                //TODO : 로그인시 이벤트 identifier 필요
               },
             },
           );

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -9,6 +9,7 @@ import ButtonSocialLogin from '@/components/ButtonSocialLogin/ButtonSocialLogin'
 import { AUTH_PROVIDER, WINDOW_CUSTOM_EVENT } from '@/constants/common';
 import { NATIVE_CUSTOM_EVENTS } from '@/constants/nativeCustomEvent';
 import { ROUTER } from '@/constants/router';
+import { eventLogger } from '@/utils';
 import { isAndroid, isIOS, isWebView } from '@/utils/appEnv';
 import { css } from '@styled-system/css';
 
@@ -74,7 +75,10 @@ export default function LoginPage() {
           idToken: event.detail.authorization.id_token,
         },
         {
-          onSuccess: () => {
+          onSuccess: (data) => {
+            if (data?.memberId) {
+              eventLogger.identify(data.memberId.toString());
+            }
             router.push(ROUTER.HOME);
           },
         },
@@ -88,7 +92,11 @@ export default function LoginPage() {
           idToken: event.detail.data.data,
         },
         {
-          onSuccess: () => {
+          onSuccess: (data) => {
+            if (data?.memberId) {
+              eventLogger.identify(data.memberId.toString());
+            }
+
             if (!!event.detail?.data?.deviceToken) {
               updateMemberFcmTokenMutate({ fcmToken: event.detail.data.deviceToken });
             }

--- a/src/app/home/AppBar.tsx
+++ b/src/app/home/AppBar.tsx
@@ -1,18 +1,23 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import Icon from '@/components/Icon';
+import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import { ROUTER } from '@/constants/router';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
+import { eventLogger } from '@/utils';
 
 function AppBar() {
+  const handleSearchClick = () => {
+    eventLogger.logEvent(EVENT_LOG_CATEGORY.HEADER, EVENT_LOG_NAME.HEADER.CLICK_SEARCH_BUTTON);
+  };
   return (
     <>
       <header className={headerCss}>
         <div className={logoWrapperCss}>
           <Image src={'/assets/10mm-logo.svg'} alt="10MM" width={68} height={20} />
         </div>
-        <Link className={searchIconWrapper} href={ROUTER.SEARCH.HOME} passHref>
+        <Link className={searchIconWrapper} href={ROUTER.SEARCH.HOME} passHref onClick={handleSearchClick}>
           <Icon name="navigation-search" size={24} color="icon.secondary" />
         </Link>
       </header>

--- a/src/app/home/FollowList.tsx
+++ b/src/app/home/FollowList.tsx
@@ -2,7 +2,9 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useFollowMembers } from '@/apis/follow';
 import UserProfile from '@/app/home/UserProfile';
 import { type FollowDataState } from '@/app/page';
+import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import { flex } from '@/styled-system/patterns';
+import { eventLogger } from '@/utils';
 
 import ProfileItem from './ProfileItem';
 
@@ -13,6 +15,9 @@ function FollowList() {
   const id = searchParams.get('id') ? Number(searchParams.get('id')) : null;
 
   const onChangeFollowData = (props: FollowDataState) => {
+    eventLogger.logEvent(EVENT_LOG_CATEGORY.HOME, EVENT_LOG_NAME.HOME.CLICK_FOLLOW_LIST, {
+      memberId: props ? props.followId : 'me',
+    });
     if (props === null) {
       router.push('/');
       return;

--- a/src/app/home/FollowMissionList.tsx
+++ b/src/app/home/FollowMissionList.tsx
@@ -4,8 +4,10 @@ import { MissionListSkeleton } from '@/app/home/home.styles';
 import MissionBadge from '@/app/home/MissionBadge';
 import Empty from '@/components/Empty/Empty';
 import { TwoLineListItem } from '@/components/ListItem';
+import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import { MISSION_CATEGORY_LABEL } from '@/constants/mission';
 import { ROUTER } from '@/constants/router';
+import { eventLogger } from '@/utils';
 import { css } from '@styled-system/css';
 import { flex } from '@styled-system/patterns';
 
@@ -72,9 +74,14 @@ export function MissionFollowListInner({ followId }: { followId: number }) {
       {data.followMissions.map((item) => {
         const status = item.missionStatus;
 
-        const moveHref = ROUTER.MISSION.FOLLOW(item.missionId.toString());
+        const handleClick = () => {
+          eventLogger.logEvent(EVENT_LOG_CATEGORY.HOME, EVENT_LOG_NAME.HOME.CLICK_FOLLOW_MISSION, {
+            status,
+          });
+        };
+
         return (
-          <Link href={moveHref} key={item.missionId}>
+          <Link onClick={handleClick} href={ROUTER.MISSION.FOLLOW(item.missionId.toString())} key={item.missionId}>
             <TwoLineListItem
               badgeElement={<MissionBadge status={status} />}
               name={item.name}

--- a/src/app/home/FollowSummary.tsx
+++ b/src/app/home/FollowSummary.tsx
@@ -5,9 +5,11 @@ import Banner from '@/components/Banner/Banner';
 import LevelProgressBar from '@/components/Graph/LevelProgressBar';
 import Icon from '@/components/Icon';
 import Thumbnail from '@/components/Thumbnail/Thumbnail';
+import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import { LEVEL_SYSTEM } from '@/constants/level';
 import { ROUTER } from '@/constants/router';
 import { gradientTextCss } from '@/constants/style/gradient';
+import { eventLogger } from '@/utils';
 import { calcProgress, getLevel } from '@/utils/result';
 import { css, cx } from '@styled-system/css';
 import { flex } from '@styled-system/patterns';
@@ -19,12 +21,16 @@ function FollowSummary({ memberId: followId, nickname: followNickname, profileIm
   const symbolStack = stackData?.symbolStack ?? 0;
   const currentLevel = getLevel(symbolStack);
   const progress = calcProgress(symbolStack);
-
+  const handleClickFollowProfile = () => {
+    eventLogger.logEvent(EVENT_LOG_CATEGORY.HOME, EVENT_LOG_NAME.HOME.CLICK_FOLLOW_PROFILE, {
+      memberId: followId,
+    });
+  };
   return (
     <div>
       <div className={followSummaryTitleCss}>
         <Thumbnail size={'h18'} url={profileImageUrl} variant="filled" />
-        <Link href={ROUTER.PROFILE.DETAIL(followId)}>
+        <Link onClick={handleClickFollowProfile} href={ROUTER.PROFILE.DETAIL(followId)}>
           <p className={followSummaryTextCss}>
             {followNickname} <Icon name={'arrow-forward'} size={12} />
           </p>

--- a/src/app/home/MissionList.tsx
+++ b/src/app/home/MissionList.tsx
@@ -3,15 +3,21 @@
 import Link from 'next/link';
 import MissionListInner from '@/app/home/MissionInnerList';
 import Icon from '@/components/Icon';
+import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import { ROUTER } from '@/constants/router';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
+import { eventLogger } from '@/utils';
 
 function Header() {
+  const handlePlusClick = () => {
+    eventLogger.logEvent(EVENT_LOG_CATEGORY.HOME, EVENT_LOG_NAME.HOME.CLICK_PLUS_BUTTON);
+  };
+
   return (
     <h2 className={headingCss}>
       <span>내 미션 목록</span>
-      <Link href={ROUTER.MISSION.NEW}>
+      <Link href={ROUTER.MISSION.NEW} onClick={handlePlusClick}>
         <Icon name="plus" size={20} />
       </Link>
     </h2>

--- a/src/app/level/guide/page.tsx
+++ b/src/app/level/guide/page.tsx
@@ -8,8 +8,10 @@ import LockedCharacter from '@/components/Level/LockedCharacter';
 import LevelStatus from '@/components/LevelStatus/LevelStatus';
 import LoadingSpinner from '@/components/Loading/LoadingSpinner';
 import MotionDiv from '@/components/Motion/MotionDiv';
+import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import { LEVEL_SYSTEM } from '@/constants/level';
 import { css, cx } from '@/styled-system/css';
+import { eventLogger } from '@/utils';
 import { getLevel } from '@/utils/result';
 
 function LevelGuidePage() {
@@ -21,6 +23,13 @@ function LevelGuidePage() {
 
   const selectLevelInfo = LEVEL_SYSTEM[selectLevel - 1];
   const isLockedLevel = currentLevelInfo.level < selectLevelInfo.level;
+
+  const handleClickedLevel = (level: number) => {
+    eventLogger.logEvent(EVENT_LOG_CATEGORY.LEVEL, EVENT_LOG_NAME.LEVEL.CLICK_LEVEL, {
+      level,
+    });
+    setSelectLevel(level);
+  };
 
   useEffect(() => {
     if (currentLevelInfo) {
@@ -59,11 +68,7 @@ function LevelGuidePage() {
         )}
       </div>
       <section className={growthSectionCss}>
-        <GrowthLevel
-          selectLevel={selectLevel}
-          onClick={(level) => setSelectLevel(level)}
-          maxLevel={currentLevelInfo.level}
-        />
+        <GrowthLevel selectLevel={selectLevel} onClick={handleClickedLevel} maxLevel={currentLevelInfo.level} />
       </section>
     </div>
   );

--- a/src/app/mission/[id]/detail/MissionCalender/MissionCalendar.tsx
+++ b/src/app/mission/[id]/detail/MissionCalender/MissionCalendar.tsx
@@ -7,7 +7,9 @@ import {
 } from '@/app/mission/[id]/detail/MissionCalender/MissionCalendar.utils';
 import MissionCalendarItem from '@/app/mission/[id]/detail/MissionCalender/MissionCalendarItem';
 import Icon from '@/components/Icon';
+import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import useCalendar from '@/hooks/useCalendar';
+import { eventLogger } from '@/utils';
 import { css } from '@styled-system/css';
 import dayjs, { type Dayjs } from 'dayjs';
 
@@ -34,6 +36,29 @@ function MissionCalendar({
   });
   const missionStartedAt = data?.missionStartedAt || '';
 
+  const handlePrevMonth = () => {
+    eventLogger.logEvent(EVENT_LOG_CATEGORY.MISSION_DETAIL, EVENT_LOG_NAME.MISSION_DETAIL.CLICK_CALENDER_ARROW, {
+      direction: 'prev',
+      isFollow: isFollow || false,
+    });
+    onPrevMonth();
+  };
+
+  const handleNextMonth = () => {
+    eventLogger.logEvent(EVENT_LOG_CATEGORY.MISSION_DETAIL, EVENT_LOG_NAME.MISSION_DETAIL.CLICK_CALENDER_ARROW, {
+      direction: 'next',
+      isFollow: isFollow || false,
+    });
+    onNextMonth();
+  };
+
+  const handleClickCalendarItem = (isToday: boolean) => {
+    eventLogger.logEvent(EVENT_LOG_CATEGORY.MISSION_DETAIL, EVENT_LOG_NAME.MISSION_DETAIL.CLICK_CALENDER, {
+      isToday,
+      isFollow: isFollow || false,
+    });
+  };
+
   return (
     <section>
       <div
@@ -43,14 +68,14 @@ function MissionCalendar({
           gap: '4px',
         })}
       >
-        <button type={'button'} className={buttonCss} onClick={onPrevMonth}>
+        <button type={'button'} className={buttonCss} onClick={handlePrevMonth}>
           <Icon name="arrow-back" size={12} />
         </button>
         <div className={missionHistoryCalendarCss}>
           {currentYear}년 {currentMonth}월
         </div>
         {!isCurrentMonth && (
-          <button type={'button'} className={buttonCss} onClick={onNextMonth}>
+          <button type={'button'} className={buttonCss} onClick={handleNextMonth}>
             <Icon name="arrow-forward" size={12} />
           </button>
         )}
@@ -80,7 +105,7 @@ function MissionCalendar({
                 return (
                   <td key={`${day.year}-${day.month}-${day.date}`} className={missionCalendarTdCss}>
                     {routerLink ? (
-                      <Link href={routerLink}>
+                      <Link href={routerLink} onClick={() => handleClickCalendarItem(isToday)}>
                         <MissionCalendarItem date={day.date} {...restProps} isActive={isToday} />
                       </Link>
                     ) : (

--- a/src/app/mypage/MyProfile.tsx
+++ b/src/app/mypage/MyProfile.tsx
@@ -8,8 +8,10 @@ import MyProfileMissionList from '@/app/mypage/MyProfileMissionList';
 import ProfileContent from '@/app/profile/[id]/ProfileContent';
 import Button from '@/components/Button/Button';
 import Tab from '@/components/Tab/Tab';
+import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import { ROUTER } from '@/constants/router';
 import { css } from '@/styled-system/css';
+import { eventLogger } from '@/utils';
 
 const tabs = [
   {
@@ -25,6 +27,9 @@ export default function MyProfile() {
   const symbolStack = symbolStackData?.symbolStack ?? 0;
   const { data: followCountData } = useFollowsCountMembers();
 
+  const handleProfileEditClick = () => {
+    eventLogger.logEvent(EVENT_LOG_CATEGORY.MY_PAGE, EVENT_LOG_NAME.MY_PAGE.CLICK_EDIT);
+  };
   return (
     <ProfileContent
       memberId={memberId}
@@ -34,7 +39,7 @@ export default function MyProfile() {
       followerCount={followCountData?.followerCount || 0}
       followingCount={followCountData?.followingCount || 0}
       rightElement={
-        <Link href={ROUTER.MYPAGE.PROFILE_MODIFY}>
+        <Link href={ROUTER.MYPAGE.PROFILE_MODIFY} onClick={handleProfileEditClick}>
           <Button className={profileEditButtonCss} color="gray">
             프로필 수정
           </Button>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -3,16 +3,21 @@ import Link from 'next/link';
 import AppBarBottom from '@/components/AppBarBottom/AppBarBottom';
 import BottomDim from '@/components/BottomDim/BottomDim';
 import Icon from '@/components/Icon';
+import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import { ROUTER } from '@/constants/router';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
+import { eventLogger } from '@/utils';
 
 import MyProfile from './MyProfile';
 
 function Header() {
+  const handleClickSetting = () => {
+    eventLogger.logEvent(EVENT_LOG_CATEGORY.MY_PAGE, EVENT_LOG_NAME.MY_PAGE.CLICK_SETTING);
+  };
   return (
     <h2 className={headingCss}>
-      <Link className={iconWrapperCss} href={ROUTER.MYPAGE.SETTING}>
+      <Link className={iconWrapperCss} onClick={handleClickSetting} href={ROUTER.MYPAGE.SETTING}>
         <Icon name="normal-setting" size={20} color="icon.primary" />
       </Link>
     </h2>

--- a/src/app/profile/[id]/FollowButton.tsx
+++ b/src/app/profile/[id]/FollowButton.tsx
@@ -5,12 +5,15 @@ import { FollowStatus } from '@/apis/schema/member';
 import Button from '@/components/Button/Button';
 import GradientTextButton from '@/components/Button/GradientTextButton';
 import { useSnackBar } from '@/components/SnackBar/SnackBarProvider';
+import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
+import { eventLogger } from '@/utils';
 import { css } from '@styled-system/css';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 function FollowButton({ followStatus, memberId }: { followStatus: FollowStatus; memberId: number }) {
   const { triggerSnackBar } = useSnackBar();
   const queryClient = useQueryClient();
+
   const { mutateAsync: followMutate } = useMutation({
     mutationFn: FOLLOW_API.addFollow,
     onSuccess: () => {
@@ -44,12 +47,15 @@ function FollowButton({ followStatus, memberId }: { followStatus: FollowStatus; 
   });
 
   const handleFollow = async () => {
+    eventLogger.logEvent(EVENT_LOG_CATEGORY.FOLLOW_PROFILE, EVENT_LOG_NAME.FOLLOW_PROFILE.CLICK_FOLLOW_BUTTON);
     await followMutate(memberId);
   };
 
   const handleUnfollow = async () => {
+    eventLogger.logEvent(EVENT_LOG_CATEGORY.FOLLOW_PROFILE, EVENT_LOG_NAME.FOLLOW_PROFILE.CLICK_UNFOLLOW_BUTTON);
     await unFollowMutate(memberId);
   };
+
   switch (followStatus) {
     case FollowStatus.FOLLOWED_BY_ME:
       return <GradientTextButton onClick={handleFollow}>맞팔로우</GradientTextButton>;

--- a/src/app/profile/[id]/ProfileContent.tsx
+++ b/src/app/profile/[id]/ProfileContent.tsx
@@ -2,7 +2,9 @@ import { type PropsWithChildren } from 'react';
 import Link from 'next/link';
 import Banner from '@/components/Banner/Banner';
 import Thumbnail from '@/components/Thumbnail/Thumbnail';
+import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import { ROUTER } from '@/constants/router';
+import { eventLogger } from '@/utils';
 import { css } from '@styled-system/css';
 
 interface ProfileContentProps {
@@ -25,6 +27,12 @@ function ProfileContent({
   children,
   memberId,
 }: PropsWithChildren<ProfileContentProps>) {
+  const handleClickFollowList = () => {
+    eventLogger.logEvent(EVENT_LOG_CATEGORY.MY_PAGE, EVENT_LOG_NAME.MY_PAGE.CLICK_FOLLOW);
+  };
+  const handleClickFollowProfile = () => {
+    eventLogger.logEvent(EVENT_LOG_CATEGORY.MY_PAGE, EVENT_LOG_NAME.MY_PAGE.CLICK_LEVEL_BANNER);
+  };
   return (
     <div className={containerCss}>
       <section className={myTabContainerCss}>
@@ -35,13 +43,18 @@ function ProfileContent({
           <div>
             <p className={userNameCss}>{nickname}</p>
             <span className={followerTabCss}>
-              <Link href={ROUTER.PROFILE.FOLLOW_LIST(memberId, 'following')}>팔로잉 {followingCount}</Link> &nbsp;
-              <Link href={ROUTER.PROFILE.FOLLOW_LIST(memberId, 'follower')}>팔로워 {followerCount}</Link>
+              <Link onClick={handleClickFollowList} href={ROUTER.PROFILE.FOLLOW_LIST(memberId, 'following')}>
+                팔로잉 {followingCount}
+              </Link>{' '}
+              &nbsp;
+              <Link onClick={handleClickFollowList} href={ROUTER.PROFILE.FOLLOW_LIST(memberId, 'follower')}>
+                팔로워 {followerCount}
+              </Link>
             </span>
           </div>
           {rightElement}
         </div>
-        <Link href={ROUTER.LEVEL.GUIDE}>
+        <Link href={ROUTER.LEVEL.GUIDE} onClick={handleClickFollowProfile}>
           <Banner type="level" symbolStack={symbolStack} />
         </Link>
         {children}

--- a/src/app/profile/[id]/ProfileContent.tsx
+++ b/src/app/profile/[id]/ProfileContent.tsx
@@ -28,7 +28,7 @@ function ProfileContent({
   memberId,
 }: PropsWithChildren<ProfileContentProps>) {
   const handleClickFollowList = () => {
-    eventLogger.logEvent(EVENT_LOG_CATEGORY.MY_PAGE, EVENT_LOG_NAME.MY_PAGE.CLICK_FOLLOW);
+    eventLogger.logEvent(EVENT_LOG_CATEGORY.MY_PAGE, EVENT_LOG_NAME.MY_PAGE.CLICK_FOLLOW_BUTTON);
   };
   const handleClickFollowProfile = () => {
     eventLogger.logEvent(EVENT_LOG_CATEGORY.MY_PAGE, EVENT_LOG_NAME.MY_PAGE.CLICK_LEVEL_BANNER);

--- a/src/app/profile/[id]/ProfileContent.tsx
+++ b/src/app/profile/[id]/ProfileContent.tsx
@@ -28,7 +28,7 @@ function ProfileContent({
   memberId,
 }: PropsWithChildren<ProfileContentProps>) {
   const handleClickFollowList = () => {
-    eventLogger.logEvent(EVENT_LOG_CATEGORY.MY_PAGE, EVENT_LOG_NAME.MY_PAGE.CLICK_FOLLOW_BUTTON);
+    eventLogger.logEvent(EVENT_LOG_CATEGORY.MY_PAGE, EVENT_LOG_NAME.MY_PAGE.CLICK_FOLLOW_FOLLOW);
   };
   const handleClickFollowProfile = () => {
     eventLogger.logEvent(EVENT_LOG_CATEGORY.MY_PAGE, EVENT_LOG_NAME.MY_PAGE.CLICK_LEVEL_BANNER);

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -7,9 +7,11 @@ import Banner from '@/components/Banner/Banner';
 import LinkButton from '@/components/Button/LinkButton';
 import MotionDiv from '@/components/Motion/MotionDiv';
 import Tab from '@/components/Tab/Tab';
+import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import { ROUTER } from '@/constants/router';
 import { css } from '@/styled-system/css';
 import { flex, grid } from '@/styled-system/patterns';
+import { eventLogger } from '@/utils';
 import { getLevel } from '@/utils/result';
 
 import LevelStatus from '../../components/LevelStatus/LevelStatus';
@@ -29,11 +31,14 @@ function ResultPage() {
   const totalTime = `${data?.totalMissionHour ?? 0}h ${data?.totalMissionMinute ?? 0}m`;
   const totalMissionAttainRate = `${data?.totalMissionAttainRate ?? 0}%`;
 
+  const handleLevelGuideClick = () => {
+    eventLogger.logEvent(EVENT_LOG_CATEGORY.RESULT, EVENT_LOG_NAME.RESULT.CLICK_MISSION);
+  };
   return (
     <div>
       <section className={topWrapperCss}>
         <Tab tabs={TAB} activeTab="result" />
-        <LinkButton size="small" variant="secondary" href={ROUTER.LEVEL.GUIDE}>
+        <LinkButton onClick={handleLevelGuideClick} size="small" variant="secondary" href={ROUTER.LEVEL.GUIDE}>
           레벨 안내
         </LinkButton>
       </section>

--- a/src/components/AppBarBottom/AppBarBottomVIew.tsx
+++ b/src/components/AppBarBottom/AppBarBottomVIew.tsx
@@ -1,8 +1,10 @@
 import Link from 'next/link';
 import Icon from '@/components/Icon';
+import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import { NAVIGATION, type NavigationItemType } from '@/constants/navigation';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
+import { eventLogger } from '@/utils';
 
 interface Props {
   current: string;
@@ -10,12 +12,24 @@ interface Props {
 }
 
 function AppBarBottomView(props: Props) {
+  const handleClick = (tabName: string) => {
+    eventLogger.logEvent(EVENT_LOG_NAME.BOTTOM_APP_BAR.CLICK_TAB, EVENT_LOG_CATEGORY.BOTTOM_APP_BAR, {
+      tabName,
+    });
+  };
   return (
     <article className={containerCss}>
       {NAVIGATION.map((item) => {
         const isActive = item.key === props.current;
         return (
-          <Link key={item.key} href={item.path} passHref>
+          <Link
+            key={item.key}
+            href={item.path}
+            passHref
+            onClick={() => {
+              handleClick(item.name);
+            }}
+          >
             <div
               onClick={() => props.onClick?.(item)}
               className={css(itemCss, {

--- a/src/components/ListItem/Follow/MemberItem.tsx
+++ b/src/components/ListItem/Follow/MemberItem.tsx
@@ -2,6 +2,8 @@ import { useAddFollow, useDeleteFollow } from '@/apis/follow';
 import { type FollowerMemberWithStatusType, FollowStatus } from '@/apis/schema/member';
 import Button from '@/components/Button/Button';
 import { ProfileListItem } from '@/components/ListItem';
+import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
+import { eventLogger } from '@/utils';
 
 export interface MemberItemProps extends FollowerMemberWithStatusType {
   onButtonClick?: (item: FollowerMemberWithStatusType) => void;
@@ -44,6 +46,7 @@ export function NotFollowingMember(props: MemberItemProps) {
   });
 
   const onFollowerClick = async () => {
+    eventLogger.logEvent(EVENT_LOG_CATEGORY.FOLLOW_LIST, EVENT_LOG_NAME.FOLLOW_LIST.CLICK_FOLLOW_BUTTON);
     mutate(props.memberId);
   };
 

--- a/src/constants/eventLog.ts
+++ b/src/constants/eventLog.ts
@@ -5,11 +5,18 @@ export const EVENT_LOG_CATEGORY = {
   HEADER: 'header',
   BOTTOM_APP_BAR: 'bottom_app_bar',
   HOME: 'home',
+  RESULT: 'result',
+  LEVEL: 'level',
+  MISSION_DETAIL: 'mission_detail',
 };
 
 type EventLogCategoryType = keyof typeof EVENT_LOG_CATEGORY;
 
 export const EVENT_LOG_NAME = {
+  MISSION_DETAIL: {
+    CLICK_CALENDER_ARROW: 'click/calendarArrow',
+    CLICK_CALENDER: 'click/calendar',
+  },
   HOME: {
     CLICK_FOLLOW_MISSION: 'click/followMission',
     CLICK_FOLLOW_PROFILE: 'click/followProfile',
@@ -45,5 +52,11 @@ export const EVENT_LOG_NAME = {
   },
   BOTTOM_APP_BAR: {
     CLICK_TAB: 'click/tab',
+  },
+  RESULT: {
+    CLICK_MISSION: 'click/levelGuide',
+  },
+  LEVEL: {
+    CLICK_LEVEL: 'click/level',
   },
 } satisfies Record<EventLogCategoryType, Record<string, string>>;

--- a/src/constants/eventLog.ts
+++ b/src/constants/eventLog.ts
@@ -3,11 +3,18 @@ export const EVENT_LOG_CATEGORY = {
   STOPWATCH: 'stopwatch',
   CERTIFICATION: 'certification',
   HEADER: 'header',
+  BOTTOM_APP_BAR: 'bottom_app_bar',
+  HOME: 'home',
 };
 
 type EventLogCategoryType = keyof typeof EVENT_LOG_CATEGORY;
 
-export const EVENT_LOG_NAME: Record<EventLogCategoryType, Record<string, string>> = {
+export const EVENT_LOG_NAME = {
+  HOME: {
+    CLICK_FOLLOW_MISSION: 'click/followMission',
+    CLICK_FOLLOW_PROFILE: 'click/followProfile',
+    CLICK_FOLLOW_LIST: 'click/followList',
+  },
   SELECT_CATEGORY: {
     CLICK_NEXT_BUTTON: 'click/nextButton',
     CLICK_SELECT_CATEGORY: 'click/selectCategory',
@@ -34,5 +41,9 @@ export const EVENT_LOG_NAME: Record<EventLogCategoryType, Record<string, string>
   },
   HEADER: {
     CLICK_BACK_BUTTON: 'click/backButton',
+    CLICK_SEARCH_BUTTON: 'click/searchButton',
   },
-};
+  BOTTOM_APP_BAR: {
+    CLICK_TAB: 'click/tab',
+  },
+} satisfies Record<EventLogCategoryType, Record<string, string>>;

--- a/src/constants/eventLog.ts
+++ b/src/constants/eventLog.ts
@@ -10,6 +10,7 @@ export const EVENT_LOG_CATEGORY = {
   MISSION_DETAIL: 'mission_detail',
   MY_PAGE: 'my_page',
   FOLLOW_LIST: 'follow_list',
+  FOLLOW_PROFILE: 'follow_profile',
 };
 
 type EventLogCategoryType = keyof typeof EVENT_LOG_CATEGORY;
@@ -66,10 +67,14 @@ export const EVENT_LOG_NAME = {
   MY_PAGE: {
     CLICK_EDIT: 'click/edit',
     CLICK_LEVEL_BANNER: 'click/levelBanner',
-    CLICK_FOLLOW_BUTTON: 'click/followButton',
+    CLICK_FOLLOW_FOLLOW: 'click/followFollow',
     CLICK_SETTING: 'click/setting',
   },
   FOLLOW_LIST: {
     CLICK_FOLLOW_BUTTON: 'click/followButton',
+  },
+  FOLLOW_PROFILE: {
+    CLICK_FOLLOW_BUTTON: 'click/followButton',
+    CLICK_UNFOLLOW_BUTTON: 'click/unfollowButton',
   },
 } satisfies Record<EventLogCategoryType, Record<string, string>>;

--- a/src/constants/eventLog.ts
+++ b/src/constants/eventLog.ts
@@ -8,6 +8,7 @@ export const EVENT_LOG_CATEGORY = {
   RESULT: 'result',
   LEVEL: 'level',
   MISSION_DETAIL: 'mission_detail',
+  MY_PAGE: 'my_page',
 };
 
 type EventLogCategoryType = keyof typeof EVENT_LOG_CATEGORY;
@@ -21,6 +22,7 @@ export const EVENT_LOG_NAME = {
     CLICK_FOLLOW_MISSION: 'click/followMission',
     CLICK_FOLLOW_PROFILE: 'click/followProfile',
     CLICK_FOLLOW_LIST: 'click/followList',
+    CLICK_PLUS_BUTTON: 'click/plusButton',
   },
   SELECT_CATEGORY: {
     CLICK_NEXT_BUTTON: 'click/nextButton',
@@ -58,5 +60,10 @@ export const EVENT_LOG_NAME = {
   },
   LEVEL: {
     CLICK_LEVEL: 'click/level',
+  },
+  MY_PAGE: {
+    CLICK_EDIT: 'click/edit',
+    CLICK_LEVEL_BANNER: 'click/levelBanner',
+    CLICK_FOLLOW: 'click/follow',
   },
 } satisfies Record<EventLogCategoryType, Record<string, string>>;

--- a/src/constants/eventLog.ts
+++ b/src/constants/eventLog.ts
@@ -9,6 +9,7 @@ export const EVENT_LOG_CATEGORY = {
   LEVEL: 'level',
   MISSION_DETAIL: 'mission_detail',
   MY_PAGE: 'my_page',
+  FOLLOW_LIST: 'follow_list',
 };
 
 type EventLogCategoryType = keyof typeof EVENT_LOG_CATEGORY;
@@ -64,7 +65,10 @@ export const EVENT_LOG_NAME = {
   MY_PAGE: {
     CLICK_EDIT: 'click/edit',
     CLICK_LEVEL_BANNER: 'click/levelBanner',
-    CLICK_FOLLOW: 'click/follow',
+    CLICK_FOLLOW_BUTTON: 'click/followButton',
     CLICK_SETTING: 'click/setting',
+  },
+  FOLLOW_LIST: {
+    CLICK_FOLLOW_BUTTON: 'click/followButton',
   },
 } satisfies Record<EventLogCategoryType, Record<string, string>>;

--- a/src/constants/eventLog.ts
+++ b/src/constants/eventLog.ts
@@ -65,5 +65,6 @@ export const EVENT_LOG_NAME = {
     CLICK_EDIT: 'click/edit',
     CLICK_LEVEL_BANNER: 'click/levelBanner',
     CLICK_FOLLOW: 'click/follow',
+    CLICK_SETTING: 'click/setting',
   },
 } satisfies Record<EventLogCategoryType, Record<string, string>>;


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
event logging 추가

## 🎉 변경 사항
- 이벤트 로깅 추가한 부분 

바텀 앱바 클릭 :  'click/tab'
결과 페이지 레벨 가이드 버튼 : 'click/levelGuide'
레벨 페이지 레벨 아이콘 클릭 :'click/level'
마이페이지 수정 버튼 : 'click/edit'
마이페이지 세팅 버튼 : 'click/setting'
마이페이지 레벨 배너 버튼 : 'click/levelBanner'
마이페이지 팔로우 리스트 버튼 : 'click/followFollow'

팔로우 프로필 팔로우 버튼 : 'click/followButton'

팔로우 리스트 팔로우 버튼 : 'click/followButton'


더 추가했으면 좋겠는 부분 알려주시면 추가하겠습니다.

### 🙏 여기는 꼭 봐주세요!
- 로그인 시에 memberId를 서버에서 받아와 각 이벤트 logging 에 identify 를 실행하려합니다. 관련 로직 점검해주세요! cc @woobottle 

서버에서 memberId를 받기로 했습니다 
관련 슬랙 :  https://depromeet14th.slack.com/archives/C06C1271G56/p1707413630609489

### 사용 방법

## 🌄 스크린샷

## 📚 참고
