### PR TITLE
[Design] 홈에서 뜨는 미션 리스트들 그냥 기존처럼 애니메이션 없이 바로 뜨는 방향으로 수정

### DIFF
--- a/src/app/home/FollowMissionList.tsx
+++ b/src/app/home/FollowMissionList.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link';
 import { useFollowMissions } from '@/apis/follow';
-import { MissionListSkeleton } from '@/app/home/home.styles';
 import MissionBadge from '@/app/home/MissionBadge';
 import Empty from '@/components/Empty/Empty';
 import { TwoLineListItem } from '@/components/ListItem';

--- a/src/app/home/FollowMissionList.tsx
+++ b/src/app/home/FollowMissionList.tsx
@@ -53,14 +53,14 @@ const listCss = flex({
 });
 
 export function MissionFollowListInner({ followId }: { followId: number }) {
-  const { data, isLoading } = useFollowMissions(followId);
-  if (isLoading) {
-    return (
-      <ul className={listCss}>
-        <MissionListSkeleton />
-      </ul>
-    );
-  }
+  const { data } = useFollowMissions(followId);
+  // if (isLoading) {
+  //   return (
+  //     <ul className={listCss}>
+  //       <MissionListSkeleton />
+  //     </ul>
+  //   );
+  // }
 
   if (!data) {
     return null;

--- a/src/app/home/FollowMissionList.tsx
+++ b/src/app/home/FollowMissionList.tsx
@@ -4,6 +4,7 @@ import { MissionListSkeleton } from '@/app/home/home.styles';
 import MissionBadge from '@/app/home/MissionBadge';
 import Empty from '@/components/Empty/Empty';
 import { TwoLineListItem } from '@/components/ListItem';
+import { stagger } from '@/components/Motion/Motion.constants';
 import StaggerWrapper from '@/components/Motion/StaggerWrapper';
 import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import { MISSION_CATEGORY_LABEL } from '@/constants/mission';
@@ -74,7 +75,7 @@ export function MissionFollowListInner({ followId }: { followId: number }) {
   }
 
   return (
-    <StaggerWrapper wrapperOverrideCss={listCss}>
+    <StaggerWrapper wrapperOverrideCss={listCss} staggerVariants={stagger(0.02)}>
       {data.followMissions.map((item) => {
         const status = item.missionStatus;
 

--- a/src/app/home/MissionInnerList.tsx
+++ b/src/app/home/MissionInnerList.tsx
@@ -5,6 +5,7 @@ import { MissionListSkeleton } from '@/app/home/home.styles';
 import MissionBadge from '@/app/home/MissionBadge';
 import MissionEmptyList from '@/app/home/MissionEmptyList';
 import { TwoLineListItem } from '@/components/ListItem';
+import { stagger } from '@/components/Motion/Motion.constants';
 import StaggerWrapper from '@/components/Motion/StaggerWrapper';
 import { MISSION_CATEGORY_LABEL } from '@/constants/mission';
 import { ROUTER } from '@/constants/router';
@@ -26,7 +27,7 @@ function MissionListInner() {
   }
 
   return (
-    <StaggerWrapper wrapperOverrideCss={listCss}>
+    <StaggerWrapper wrapperOverrideCss={listCss} staggerVariants={stagger(0.02)}>
       {missionList.map((item) => {
         const isProgressingMission = progressMissionId === String(item.missionId);
         const status = isProgressingMission ? MissionStatus.PROGRESSING : item.missionStatus;


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
closed #520 
- 홈에서 뜨는 미션 리스트들 그냥 기존처럼 애니메이션 없이 바로 뜨는 방향으로 수정해달라는 @채연의 요청사항
- 검색페이지와 동일한 0.02 delay로 수정
<!-- 관련 이슈를 적어주세요 -->
<!-- closed #1-->

## 🎉 변경 사항
- 팔로워 미션 리스트에서는 스켈레톤이 거슬린다고 생각했어요. 그래서 팔로워 미션리스트에서만 제거하였습니다. 
- 내 미션 리스트에서는 스켈레톤을 유지하였습니다 -> 종종 딜레이가 걸리거나 오류가 발생하는 것을 봤기 떄문입니당. 
