### PR TITLE
[Feat] 프로필 링크 복사 기능

### DIFF
--- a/src/apis/instance.api.ts
+++ b/src/apis/instance.api.ts
@@ -30,7 +30,7 @@ const setInterceptors = (instance: AxiosInstance) => {
       if (axios.isAxiosError(error)) {
         if (error.response?.status === 401) {
           if (typeof window !== 'undefined') {
-            window.location.href = ROUTER.AUTH.LOGIN;
+            window.location.href = ROUTER.AUTH.LOGIN + '?redirect=' + window.location.pathname;
           }
         }
       }

--- a/src/app/auth/kakaoCallback/page.tsx
+++ b/src/app/auth/kakaoCallback/page.tsx
@@ -32,7 +32,8 @@ export default function KakaoCallbackPage() {
                 if (successData?.memberId) {
                   eventLogger.identify(successData.memberId.toString());
                 }
-                router.push(ROUTER.HOME);
+
+                router.push(params.get('state') ?? ROUTER.HOME);
               },
             },
           );

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Script from 'next/script';
 import { useSocialLogin, useUpdateMemberFcmToken } from '@/apis/auth';
 import Button from '@/components/Button/Button';
@@ -33,7 +33,8 @@ export default function LoginPage() {
   const router = useRouter();
   const { mutateAsync: socialLoginAsyncMutate } = useSocialLogin();
   const { mutate: updateMemberFcmTokenMutate } = useUpdateMemberFcmToken();
-
+  const search = useSearchParams();
+  const redirectUrl = search.get('redirect') ?? ROUTER.HOME;
   const onClickGuest = () => {
     router.push(ROUTER.GUEST.MISSION.NEW);
   };
@@ -64,6 +65,7 @@ export default function LoginPage() {
       redirectUri: process.env.NEXT_PUBLIC_KAKAO_LOGIN_REDIRECT_URI,
       nonce: process.env.NEXT_PUBLIC_SNS_LOGIN_NONCE,
       throughTalk: isAndroid() ? false : true,
+      state: redirectUrl,
     });
   };
 
@@ -79,7 +81,7 @@ export default function LoginPage() {
             if (data?.memberId) {
               eventLogger.identify(data.memberId.toString());
             }
-            router.push(ROUTER.HOME);
+            router.push(redirectUrl);
           },
         },
       );
@@ -100,7 +102,8 @@ export default function LoginPage() {
             if (!!event.detail?.data?.deviceToken) {
               updateMemberFcmTokenMutate({ fcmToken: event.detail.data.deviceToken });
             }
-            router.push(ROUTER.HOME);
+            // 지금 당장은 필요없지만 나중을 위해 작동하도록 한다
+            router.push(redirectUrl);
           },
           onError: () => {
             window.Kakao.Auth.authorize({

--- a/src/app/global.d.ts
+++ b/src/app/global.d.ts
@@ -1,3 +1,10 @@
+interface KakaoAuthParams {
+  redirectUri?: string;
+  nonce?: string;
+  throughTalk: boolean;
+  state?: string;
+}
+
 declare global {
   interface Window {
     ReactNativeWebView: {
@@ -7,7 +14,7 @@ declare global {
       init: (keyValue: string) => void;
       isInitialized: () => boolean;
       Auth: {
-        authorize: ({ redirectUri: string, nonce: string, throughTalk: boolean }) => void;
+        authorize: (prams: KakaoAuthParams) => void;
       };
     };
     AppleID: {

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -26,10 +26,12 @@ function Header() {
       await copyClipBoard(window.location.origin + ROUTER.PROFILE.DETAIL(data.memberId));
       triggerSnackBar({
         message: '링크가 복사되었습니다.',
+        offset: 'appBar',
       });
     } catch (e) {
       triggerSnackBar({
         message: '링크 복사에 실패하였습니다. 다시시도해주세요.',
+        offset: 'appBar',
       });
     }
   };

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -23,14 +23,17 @@ function Header() {
   const handleClickShare = async () => {
     if (!data) return;
     try {
+      if (window.navigator?.share) {
+        window.navigator.share({
+          title: '10mm',
+          text: '내 프로필 링크 공유하기',
+          url: window.location.origin + ROUTER.PROFILE.DETAIL(data.memberId),
+        });
+      }
+    } catch (e) {
       await copyClipBoard(window.location.origin + ROUTER.PROFILE.DETAIL(data.memberId));
       triggerSnackBar({
         message: '링크가 복사되었습니다.',
-        offset: 'appBar',
-      });
-    } catch (e) {
-      triggerSnackBar({
-        message: '링크 복사에 실패하였습니다. 다시시도해주세요.',
         offset: 'appBar',
       });
     }

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,22 +1,44 @@
 'use client';
 import Link from 'next/link';
+import { useGetMembersMe } from '@/apis/member';
 import AppBarBottom from '@/components/AppBarBottom/AppBarBottom';
 import BottomDim from '@/components/BottomDim/BottomDim';
 import Icon from '@/components/Icon';
+import { useSnackBar } from '@/components/SnackBar/SnackBarProvider';
 import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import { ROUTER } from '@/constants/router';
 import { css } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
-import { eventLogger } from '@/utils';
+import { copyClipBoard, eventLogger } from '@/utils';
 
 import MyProfile from './MyProfile';
 
 function Header() {
+  const { triggerSnackBar } = useSnackBar();
+  const { data } = useGetMembersMe();
+
   const handleClickSetting = () => {
     eventLogger.logEvent(EVENT_LOG_CATEGORY.MY_PAGE, EVENT_LOG_NAME.MY_PAGE.CLICK_SETTING);
   };
+  const handleClickShare = async () => {
+    if (!data) return;
+    try {
+      await copyClipBoard(window.location.origin + ROUTER.PROFILE.DETAIL(data.memberId));
+      triggerSnackBar({
+        message: '링크가 복사되었습니다.',
+      });
+    } catch (e) {
+      triggerSnackBar({
+        message: '링크 복사에 실패하였습니다. 다시시도해주세요.',
+      });
+    }
+  };
+
   return (
     <h2 className={headingCss}>
+      <button type={'button'} className={iconWrapperCss} onClick={handleClickShare}>
+        <Icon name="normal-link" size={20} color="icon.primary" />
+      </button>
       <Link className={iconWrapperCss} onClick={handleClickSetting} href={ROUTER.MYPAGE.SETTING}>
         <Icon name="normal-setting" size={20} color="icon.primary" />
       </Link>
@@ -58,7 +80,6 @@ const headingCss = flex({
   color: 'text.primary',
   padding: '2px 8px 2px 0',
   userSelect: 'none',
-  gap: '10px',
   zIndex: 3,
 });
 const iconWrapperCss = css({

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useFollowsCountTargetId } from '@/apis/follow';
-import { useGetMembersById } from '@/apis/member';
+import { useGetMembersById, useGetMembersMe } from '@/apis/member';
 import { useGetMissionStack } from '@/apis/mission';
 import { FollowStatus } from '@/apis/schema/member';
 import ProfileTab from '@/app/mypage/ProfileTab';
@@ -15,7 +15,8 @@ function FollowProfilePage({ params }: { params: { id: string } }) {
   const { data: followCountData, isFetching } = useFollowsCountTargetId(Number(params.id));
   const { data } = useGetMembersById(Number(params.id));
   const { data: symbolStackData } = useGetMissionStack(params.id);
-
+  const { data: memebersMeData } = useGetMembersMe();
+  const isMyself = memebersMeData?.memberId === Number(params.id);
   return (
     <main className={backgroundCss}>
       <Header rightAction={'none'} headerBgColor={'transparent'} iconColor={'icon.primary'} />
@@ -27,11 +28,13 @@ function FollowProfilePage({ params }: { params: { id: string } }) {
         profileImageUrl={data?.profileImageUrl || null}
         symbolStack={symbolStackData?.symbolStack || 0}
         rightElement={
-          <FollowButton
-            followStatus={followCountData?.followStatus || FollowStatus.NOT_FOLLOWING}
-            memberId={Number(params.id)}
-            isFetching={isFetching}
-          />
+          !isMyself ? (
+            <FollowButton
+              followStatus={followCountData?.followStatus || FollowStatus.NOT_FOLLOWING}
+              memberId={Number(params.id)}
+              isFetching={isFetching}
+            />
+          ) : null
         }
       >
         <ProfileTab memberId={Number(params.id)} />

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -25,7 +25,7 @@ export function useAuth() {
     const token = localStorage.getItem('accessToken') ?? process.env.NEXT_PUBLIC_ACCESS_TOKEN;
 
     if (!token && !ALLOW_PATH_LIST.includes(pathname)) {
-      router.push(ROUTER.AUTH.LOGIN);
+      router.push(ROUTER.AUTH.LOGIN + '?redirect=' + window.location.pathname);
     }
   }, []);
 }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,1 +1,9 @@
 export const isProd = () => process.env.NODE_ENV === 'production';
+
+export const copyClipBoard = async (text: string) => {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (e) {
+    throw new Error('클립보드 복사에 실패했습니다.');
+  }
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,6 @@
 export * from './getQueryString';
 export * from './object';
 export * from './event';
+export * from './getBorderColor';
+export * from './common';
+export * from './result';


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
- 프로필 링크복사기능
- 다른 path로 들어왔을때 로그인후 해당 path로 리다이렉트

## 🎉 변경 사항

### 🙏 여기는 꼭 봐주세요!
- 카카오톡 로그인의 state 의 속성으로 callback url에서 state query prams를 같이 받아오는 로직으로 풀었습니다.
- 네이티브에서 애플로그인 / 카카오로그인은 대응은 해두었지만 제대로 동작하는지 확인은 하지 않았습니다. (네이티브에서 기존처럼 로그인하는데 문제는 없을 듯합니다) 나중에 딥링크를 붙였을때 로직을 생각해봐야겠어요

우선은 웹 동작 기준으로 대응했다고 보시면 될 것 같습니다!

피그마에서는 쉐어 아이콘으로 되어있었는데 뭔가 쉐어아이콘은 네이티브 쉐어가 떠야할 것 같아서 클립 아이콘으로 변경했습니다
(디자인 팀과 이야기 필요)

<img width="321" alt="스크린샷 2024-02-12 오전 1 38 20" src="https://github.com/depromeet/10mm-client-web/assets/68339352/cb1fa2a0-c179-471d-9bec-0f7db54fe94d">


### 사용 방법

## 🌄 

https://github.com/depromeet/10mm-client-web/assets/68339352/85d77d88-f9de-48f3-9bd3-05722ba089e1




https://github.com/depromeet/10mm-client-web/assets/68339352/3919506f-db07-45e2-8cfb-f2c25a0744f6

스크린샷

## 📚 참고
https://developers.kakao.com/docs/latest/ko/kakaologin/js#login-info