### PR TITLE
fix : header zindex 수정

### DIFF
--- a/src/components/Header/HeaderBase.tsx
+++ b/src/components/Header/HeaderBase.tsx
@@ -57,7 +57,7 @@ const wrapperCss = flex({
   left: 0,
   right: 0,
   top: 0,
-  zIndex: 100,
+  zIndex: 3,
   position: 'fixed',
   display: 'flex',
   alignItems: 'center',


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
바텀시트가 열릴때 head가 보임
<img width="598" alt="스크린샷 2024-02-12 오전 3 43 15" src="https://github.com/depromeet/10mm-client-web/assets/68339352/0643c199-ccea-482c-8c33-6ba8e61b1720">

## 🎉 변경 사항
header의 zindex를 변경했습니다. (꼭 100이여야하는 이유가 있다면 알려주세요)
라이브러리로 사용하고 있는 react-spring-bottom-sheet  에서 zIndex를 변경하기 까다로워서 header의 zindex를 낮추는 방향으로 수정하였습니다. 

### 🙏 여기는 꼭 봐주세요!



### 사용 방법


## 🌄 스크린샷
<img width="605" alt="스크린샷 2024-02-12 오전 3 39 41" src="https://github.com/depromeet/10mm-client-web/assets/68339352/7dd9f371-07c0-4d86-8234-1e755143d601">

## 📚 참고
