### PR TITLE
[Feat] Reaction 추가기능 반영

### DIFF
--- a/src/apis/reaction.ts
+++ b/src/apis/reaction.ts
@@ -43,6 +43,10 @@ interface ModifyReactionRequest {
   emojiType: EmojiType;
 }
 
+interface DeleteReactionRequest {
+  reactionId: number;
+}
+
 export const REACTION_API = {
   getReactions: async (recordId: number): Promise<GetReactionsResponse> => {
     const { data } = await apiInstance.get<GetReactionsResponse>(`/reactions?missionRecordId=${recordId}`);
@@ -53,8 +57,11 @@ export const REACTION_API = {
     return data;
   },
   modifyReaction: async ({ reactionId, emojiType }: ModifyReactionRequest) => {
-    console.log('reactionId: ', reactionId);
     const { data } = await apiInstance.put<AddReactionResponse>(`/reactions/${reactionId}`, { emojiType });
+    return data;
+  },
+  deleteReaction: async ({ reactionId }: DeleteReactionRequest) => {
+    const { data } = await apiInstance.delete<AddReactionResponse>(`/reactions/${reactionId}`);
     return data;
   },
 };

--- a/src/apis/schema/feed.ts
+++ b/src/apis/schema/feed.ts
@@ -3,6 +3,7 @@ export interface FeedItemType extends FeedBaseType {
   nickname: string;
   profileImage?: string;
   memberId: number;
+  recordStartedAt: string;
 }
 
 export interface FeedBaseType {

--- a/src/app/feed/FeedItem.tsx
+++ b/src/app/feed/FeedItem.tsx
@@ -21,7 +21,7 @@ function FeedItem({
   profileImage,
   recordImageUrl,
   duration,
-  startedAt,
+  recordStartedAt,
   recordId,
 }: FeedItemType) {
   const { memberId: myId } = useGetMyId();
@@ -54,7 +54,7 @@ function FeedItem({
           <p className={missionNameCss}>{name}</p>
           {remark && <p className={remarkCss}>{remark}</p>}
           <p className={captionCss}>
-            {sinceDay}일차 <div className={dotCss} /> {dayjs(startedAt).format('YYYY년 MM월 DD일')}
+            {sinceDay}일차 <div className={dotCss} /> {dayjs(recordStartedAt).format('YYYY년 MM월 DD일')}
           </p>
         </div>
       </Link>

--- a/src/app/home/FollowContent/FollowMissionList.tsx
+++ b/src/app/home/FollowContent/FollowMissionList.tsx
@@ -1,4 +1,5 @@
 import { useFollowMissions } from '@/apis/follow';
+import { MissionStatus } from '@/apis/schema/mission';
 import MissionList from '@/components/MissionList';
 import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import { ROUTER } from '@/constants/router';
@@ -30,6 +31,18 @@ function FollowMissionList({ followId }: FollowMissionListProps) {
           });
         };
 
+        if (item.missionRecordId && status === MissionStatus.COMPLETED) {
+          return (
+            <MissionList.ReactionLinkItem
+              href={ROUTER.MISSION.FOLLOW(item.missionId.toString())}
+              key={item.missionId}
+              recordId={Number(item.missionRecordId)}
+              onClick={() => onClickItem(true)}
+              {...item}
+            />
+          );
+        }
+
         return (
           <MissionList.LinkItem
             key={item.missionId}
@@ -44,3 +57,9 @@ function FollowMissionList({ followId }: FollowMissionListProps) {
 }
 
 export default FollowMissionList;
+
+const onClickItem = (isReaction: boolean) => {
+  eventLogger.logEvent(EVENT_LOG_CATEGORY.HOME, EVENT_LOG_NAME.HOME.CLICK_FOLLOW_MISSION, {
+    isReaction,
+  });
+};

--- a/src/app/home/FollowContent/MyMissionInnerList.tsx
+++ b/src/app/home/FollowContent/MyMissionInnerList.tsx
@@ -19,7 +19,22 @@ function MissionListInner() {
     <MissionList.Container>
       {missionList.map((item) => {
         const { moveHref, status } = getMoveHref(item, progressMissionId);
-        return <MissionList.LinkItem href={moveHref} key={item.missionId} {...item} missionStatus={status} />;
+
+        console.log('item.missionRecordId: ', item, item.missionRecordId);
+        // if (!item.missionRecordId) {
+        //   return <MissionList.LinkItem href={moveHref} key={item.missionId} {...item} missionStatus={status} />;
+        // }
+
+        return (
+          <MissionList.ReactionLinkItem
+            href={moveHref}
+            key={item.missionId}
+            {...item}
+            missionStatus={status}
+            recordId={77}
+            // recordId={Number(item.missionRecordId)}
+          />
+        );
       })}
     </MissionList.Container>
   );

--- a/src/app/home/FollowContent/MyMissionInnerList.tsx
+++ b/src/app/home/FollowContent/MyMissionInnerList.tsx
@@ -1,9 +1,10 @@
 import { type MissionItemTypeWithRecordId, MissionStatus } from '@/apis/schema/mission';
 import { useMissions } from '@/app/home/home.hooks';
 import MissionList from '@/components/MissionList';
+import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import { ROUTER } from '@/constants/router';
+import { eventLogger } from '@/utils';
 
-// TODO : 확인하기,
 function MissionListInner() {
   const { missionList, isLoading, progressMissionId } = useMissions();
 
@@ -20,19 +21,26 @@ function MissionListInner() {
       {missionList.map((item) => {
         const { moveHref, status } = getMoveHref(item, progressMissionId);
 
-        console.log('item.missionRecordId: ', item, item.missionRecordId);
-        // if (!item.missionRecordId) {
-        //   return <MissionList.LinkItem href={moveHref} key={item.missionId} {...item} missionStatus={status} />;
-        // }
+        if (item.missionRecordId && status === MissionStatus.COMPLETED) {
+          return (
+            <MissionList.ReactionLinkItem
+              href={moveHref}
+              key={item.missionId}
+              {...item}
+              missionStatus={status}
+              recordId={Number(item.missionRecordId)}
+              onClick={() => onClickItem(true)}
+            />
+          );
+        }
 
         return (
-          <MissionList.ReactionLinkItem
+          <MissionList.LinkItem
             href={moveHref}
             key={item.missionId}
             {...item}
             missionStatus={status}
-            recordId={77}
-            // recordId={Number(item.missionRecordId)}
+            onClick={() => onClickItem(false)}
           />
         );
       })}
@@ -54,4 +62,10 @@ const getMoveHref = (item: MissionItemTypeWithRecordId, progressMissionId: strin
       : ROUTER.MISSION.DETAIL(missionId);
 
   return { moveHref, status };
+};
+
+const onClickItem = (isReaction: boolean) => {
+  eventLogger.logEvent(EVENT_LOG_CATEGORY.HOME, EVENT_LOG_NAME.HOME.CLICK_MY_MISSION, {
+    isReaction,
+  });
 };

--- a/src/app/home/FollowContent/MyMissionList.tsx
+++ b/src/app/home/FollowContent/MyMissionList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import MissionListInner from '@/app/home/FollowContent/MissionInnerList';
+import MissionListInner from '@/app/home/FollowContent/MyMissionInnerList';
 import Icon from '@/components/Icon';
 import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import { ROUTER } from '@/constants/router';

--- a/src/app/home/FollowContent/index.tsx
+++ b/src/app/home/FollowContent/index.tsx
@@ -6,7 +6,7 @@ import { flex } from '@styled-system/patterns';
 
 import FollowMissionList from './FollowMissionList';
 import FollowSummary, { FollowSummarySkeleton } from './FollowSummary';
-import HomeMissionList from './MissionList';
+import HomeMissionList from './MyMissionList';
 
 function FollowContent() {
   const { data: selectedFollowData, isLoading, isFollower } = useGetSelectFollowData();

--- a/src/components/AppBarBottom/AppBarBottomVIew.tsx
+++ b/src/components/AppBarBottom/AppBarBottomVIew.tsx
@@ -57,7 +57,7 @@ const containerCss = flex({
   width: 'fit-content',
   borderRadius: '24px',
   position: 'fixed',
-  bottom: '34px', // indicator(34px)
+  bottom: '12px', // indicator(34px)
   left: 0,
   right: 0,
   margin: '16px auto',

--- a/src/components/Icon/TrashcanIcon.tsx
+++ b/src/components/Icon/TrashcanIcon.tsx
@@ -1,0 +1,33 @@
+import { DEFAULT_ICON_COLOR, type IconComponentProps } from '@/components/Icon/index';
+import { token } from '@styled-system/tokens';
+
+function TrashcanIcon(props: IconComponentProps) {
+  const { color, size = 36, ...restProps } = props;
+
+  const iconColor = color ? token.var(`colors.${color}`) : DEFAULT_ICON_COLOR;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      color={iconColor}
+      {...restProps}
+    >
+      <path
+        d="M9.40627 3.3906C9.7772 2.8342 10.4017 2.5 11.0704 2.5H12.9296C13.5983 2.5 14.2228 2.8342 14.5937 3.3906L15.5 4.75H19.25C19.6642 4.75 20 5.08579 20 5.5C20 5.91421 19.6642 6.25 19.25 6.25H4.75C4.33579 6.25 4 5.91421 4 5.5C4 5.08579 4.33579 4.75 4.75 4.75H8.5L9.40627 3.3906Z"
+        fill="currentColor"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M15 21H9C6.79086 21 5 19.2091 5 17V7.5H19V17C19 19.2091 17.2091 21 15 21ZM10 10.25C10.4142 10.25 10.75 10.5858 10.75 11V17C10.75 17.4142 10.4142 17.75 10 17.75C9.58579 17.75 9.25 17.4142 9.25 17L9.25 11C9.25 10.5858 9.58579 10.25 10 10.25ZM14 10.25C14.4142 10.25 14.75 10.5858 14.75 11V17C14.75 17.4142 14.4142 17.75 14 17.75C13.5858 17.75 13.25 17.4142 13.25 17V11C13.25 10.5858 13.5858 10.25 14 10.25Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+export default TrashcanIcon;

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -29,6 +29,7 @@ import TENMMSymbolCircleIcon, { TENMMSymbolCircleLocked } from '@/components/Ico
 import TENMMSymbolCircleNormalIcon from '@/components/Icon/TENMMSymbolCircleNormalIcon';
 import TENMMSymbolIcon from '@/components/Icon/TENMMSymbolIcon';
 import TermsIcon from '@/components/Icon/TermsIcon';
+import TrashcanIcon from '@/components/Icon/TrashcanIcon';
 import WithdrawalIcon from '@/components/Icon/WithdrawalIcon';
 import { type ColorToken } from '@styled-system/tokens';
 
@@ -91,6 +92,7 @@ export const IconComponentMap = {
   '10mm-symbol-fill': SymbolFillIcon,
   clock: ClockIcon,
   notification: NotificationIcon,
+  trashcan: TrashcanIcon,
 } as const;
 
 interface Props extends IconComponentProps {

--- a/src/components/ListItem/TwoLineListItem.tsx
+++ b/src/components/ListItem/TwoLineListItem.tsx
@@ -11,6 +11,7 @@ export interface TwoLineListItemType {
   badgeElement?: ReactNode;
 
   isBackground?: boolean; // variant `background-on` `background-off` 대체
+  children?: ReactNode;
 }
 
 function TwoLineListItem({ isBackground = true, ...props }: TwoLineListItemType) {
@@ -20,6 +21,7 @@ function TwoLineListItem({ isBackground = true, ...props }: TwoLineListItemType)
       <div className={textWrapperCss}>
         <p className={cx(oneLineTextCss, subNameCss)}>{props.subName}</p>
         <p className={cx(oneLineTextCss, nameCss)}>{props.name}</p>
+        {props.children}
       </div>
       {Boolean(props.badgeElement) && props.badgeElement}
     </li>
@@ -32,11 +34,20 @@ const containerCss = flex({
   gap: '10px',
   alignItems: 'center',
   borderRadius: '22px',
-  height: '74px',
+  // height: '74px',
   cursor: 'pointer',
+  minHeight: '74px',
 });
 
-const textWrapperCss = flex({ flex: 1, flexDirection: 'column', gap: '2px', minWidth: '0' });
+const textWrapperCss = flex({
+  flex: 1,
+  flexDirection: 'column',
+  gap: '2px',
+  minWidth: '0',
+  '& > *': {
+    minHeight: '21px',
+  },
+});
 
 const subNameCss = css({
   color: 'text.tertiary',
@@ -53,7 +64,7 @@ const bgExistContainerCss = css({
   border: '1px solid #22242F',
   background: 'linear-gradient(0deg, rgba(168, 180, 240, 0.02) 0%, rgba(168, 180, 240, 0.02) 100%), #18181D',
   boxShadow: '-10px 0px 100px 4px rgba(69, 85, 169, 0.05) inset',
-  padding: '16px',
+  padding: '10px 16px',
 });
 
 const bgNoExistContainerCss = css({

--- a/src/components/MissionList/ReactionLinkItem.tsx
+++ b/src/components/MissionList/ReactionLinkItem.tsx
@@ -1,0 +1,80 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { useGetReactions } from '@/apis/reaction';
+import { type MissionItemTypeWithRecordId } from '@/apis/schema/mission';
+import { REACTION_EMOJI_IMAGE } from '@/apis/schema/reaction';
+import { TwoLineListItem } from '@/components/ListItem';
+import MissionBadge from '@/components/MissionList/Badge';
+import { MISSION_CATEGORY_LABEL } from '@/constants/mission';
+import { css } from '@/styled-system/css';
+
+interface Props extends MissionItemTypeWithRecordId {
+  href: string;
+  onClick?: () => void; // link click event
+
+  recordId: number;
+}
+
+function ReactionLinkItem({ onClick, href, ...props }: Props) {
+  if (!href)
+    return (
+      <div onClick={onClick}>
+        <ReactionItem {...props} />
+      </div>
+    );
+
+  return (
+    <Link href={href} onClick={onClick}>
+      <ReactionItem {...props} />
+    </Link>
+  );
+}
+
+export default ReactionLinkItem;
+
+function ReactionItem(props: Omit<Props, 'href' | 'onClick'>) {
+  return (
+    <TwoLineListItem
+      badgeElement={<MissionBadge status={props.missionStatus} />}
+      name={props.name}
+      subName={MISSION_CATEGORY_LABEL[props.category].label}
+      imageUrl={MISSION_CATEGORY_LABEL[props.category].imgUrl}
+    >
+      <ReactionList recordId={props.recordId} />
+    </TwoLineListItem>
+  );
+}
+
+function ReactionList({ recordId }: { recordId: number }) {
+  const { data } = useGetReactions(recordId);
+
+  if (!data) {
+    return <div className={reactionListCss}></div>;
+  }
+
+  return (
+    <div className={reactionListCss}>
+      {data.map((item) => (
+        <div key={item.emojiType} className={reactionItemCss}>
+          <Image src={REACTION_EMOJI_IMAGE[item.emojiType]} alt={item.emojiType} width={16} height={16} />
+          <span>{item.count}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const reactionListCss = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+});
+
+const reactionItemCss = css({
+  display: 'flex',
+  alignItems: 'center',
+  color: 'gray.gray600',
+  textStyle: 'body6',
+  userSelect: 'none',
+  gap: '3px',
+});

--- a/src/components/MissionList/ReactionLinkItem.tsx
+++ b/src/components/MissionList/ReactionLinkItem.tsx
@@ -48,8 +48,8 @@ function ReactionItem(props: Omit<Props, 'href' | 'onClick'>) {
 function ReactionList({ recordId }: { recordId: number }) {
   const { data } = useGetReactions(recordId);
 
-  if (!data) {
-    return <div className={reactionListCss}></div>;
+  if (!data || data.length === 0) {
+    return null;
   }
 
   return (

--- a/src/components/MissionList/index.tsx
+++ b/src/components/MissionList/index.tsx
@@ -3,6 +3,7 @@ import MissionItem from './Item';
 import MissionLinkItem from './LinkItem';
 import MissionListContainer from './ListContainer';
 import MissionListNoticeEmpty from './NoticeEmpty';
+import ReactionLinkItem from './ReactionLinkItem';
 import MissionListSkeleton from './Skeleton';
 
 export default Object.assign(MissionListContainer, {
@@ -12,4 +13,5 @@ export default Object.assign(MissionListContainer, {
   Skeleton: MissionListSkeleton,
   SuggestAdd: MissionEmptyList,
   NoticeEmpty: MissionListNoticeEmpty,
+  ReactionLinkItem: ReactionLinkItem,
 });

--- a/src/components/ReactionBar/MyReactionBar/MyReactionBar.tsx
+++ b/src/components/ReactionBar/MyReactionBar/MyReactionBar.tsx
@@ -4,6 +4,7 @@ import Icon from '@/components/Icon';
 import { reactionBarContainerCss, titleSectionCss } from '@/components/ReactionBar/ReactionBar.style';
 import ReactionBottomSheet from '@/components/ReactionBar/ReactionBottomSheet';
 import ReactionList from '@/components/ReactionBar/ReactionList';
+import { useSnackBar } from '@/components/SnackBar/SnackBarProvider';
 import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import { css } from '@/styled-system/css';
 import { eventLogger } from '@/utils';
@@ -13,10 +14,23 @@ interface Props {
 }
 
 function MyReactionBar(props: Props) {
+  const { triggerSnackBar } = useSnackBar();
+
   const { data } = useGetReactions(props.recordId);
   const [isReactionBottomSheetShowing, setIsReactionBottomSheetShowing] = useState(false);
 
   const onOpenReactionBottomSheet = () => {
+    if (!data) return;
+
+    if (data.length === 0) {
+      // snack bar
+      triggerSnackBar({
+        message: '아직 응원한 사람이 없습니다.',
+        offset: 'appBar',
+      });
+      return;
+    }
+
     eventLogger.logEvent(EVENT_LOG_CATEGORY.REACTION, EVENT_LOG_NAME.REACTION.OPEN_BOTTOM_SHEET);
     setIsReactionBottomSheetShowing(true);
   };

--- a/src/components/ReactionBar/OtherReactionBar/OtherReactionBar.tsx
+++ b/src/components/ReactionBar/OtherReactionBar/OtherReactionBar.tsx
@@ -8,6 +8,7 @@ import MotionDiv from '@/components/Motion/MotionDiv';
 import { reactionBarContainerCss, titleSectionCss } from '@/components/ReactionBar/ReactionBar.style';
 import ReactionBottomSheet from '@/components/ReactionBar/ReactionBottomSheet';
 import ReactionList from '@/components/ReactionBar/ReactionList';
+import { useSnackBar } from '@/components/SnackBar/SnackBarProvider';
 import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import { gradientTextCss } from '@/constants/style/gradient';
 import { css } from '@/styled-system/css';
@@ -22,6 +23,7 @@ interface Props {
 }
 
 function OtherReactionBar(props: Props) {
+  const { triggerSnackBar } = useSnackBar();
   const { data, refetch, isLoading } = useGetReactions(props.recordId);
   const [selectEmoji, setSelectEmoji] = useState<SelectEmojiType>();
 
@@ -31,6 +33,17 @@ function OtherReactionBar(props: Props) {
   const { myReactionId, myEmoji } = useGetMyReactions(data as GetReactionsResponse);
 
   const onOpenReactionBottomSheet = () => {
+    if (!data) return;
+
+    if (data.length === 0) {
+      // snack bar
+      triggerSnackBar({
+        message: '아직 응원한 사람이 없습니다.',
+        offset: 'appBar',
+      });
+      return;
+    }
+
     eventLogger.logEvent(EVENT_LOG_CATEGORY.REACTION, EVENT_LOG_NAME.REACTION.OPEN_BOTTOM_SHEET);
     setIsReactionBottomSheetShowing(true);
   };

--- a/src/components/ReactionBar/OtherReactionBar/OtherReactionBar.tsx
+++ b/src/components/ReactionBar/OtherReactionBar/OtherReactionBar.tsx
@@ -193,7 +193,7 @@ const backDropCss = css({
   left: 0,
   right: 0,
   bottom: 0,
-  zIndex: 99, // bottom sheet backdrop z-index is 100
+  zIndex: 1,
 });
 
 const reactionVariant = {

--- a/src/components/ReactionBar/OtherReactionBar/OtherReactionBar.tsx
+++ b/src/components/ReactionBar/OtherReactionBar/OtherReactionBar.tsx
@@ -102,6 +102,10 @@ function OtherReactionBar(props: Props) {
         isShowing={isReactionBottomSheetShowing}
         data={data}
         onClose={() => setIsReactionBottomSheetShowing(false)}
+        onDeleteReaction={() => {
+          refetch();
+          setIsReactionBottomSheetShowing(false);
+        }}
       />
     </div>
   );

--- a/src/components/ReactionBar/OtherReactionBar/OtherReactionBar.tsx
+++ b/src/components/ReactionBar/OtherReactionBar/OtherReactionBar.tsx
@@ -193,7 +193,7 @@ const backDropCss = css({
   left: 0,
   right: 0,
   bottom: 0,
-  zIndex: 1,
+  zIndex: 99, // bottom sheet backdrop z-index is 100
 });
 
 const reactionVariant = {

--- a/src/components/ReactionBar/ReactionBottomSheet.tsx
+++ b/src/components/ReactionBar/ReactionBottomSheet.tsx
@@ -61,7 +61,7 @@ const backDropCss = css({
   left: 0,
   right: 0,
   bottom: 0,
-  zIndex: 1,
+  zIndex: 99, // bottom sheet backdrop z-index is 100
 });
 
 interface EmojiListProps {

--- a/src/components/ReactionBar/ReactionBottomSheet.tsx
+++ b/src/components/ReactionBar/ReactionBottomSheet.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
+import { useGetMyId } from '@/apis/member';
 import { type GetReactionsResponse, type ReactionType } from '@/apis/reaction';
 import { type EmojiType, REACTION_EMOJI_IMAGE } from '@/apis/schema/reaction';
 import BottomSheet from '@/components/BottomSheet/BottomSheet';
 import Header from '@/components/Header/Header';
 import { OneLineListItem } from '@/components/ListItem';
+import { ROUTER } from '@/constants/router';
 import { hiddenScrollCss } from '@/constants/style/scroll';
 import { css, cx } from '@/styled-system/css';
 import { flex } from '@/styled-system/patterns';
@@ -86,19 +89,29 @@ const emojiItemCss = flex({
 });
 
 function PeopleList({ data }: { data?: ReactionType }) {
+  const { memberId: myId } = useGetMyId();
+
   return (
     <section className={peopleListSectionCss}>
       {data?.reactions.map((reaction) => (
-        <OneLineListItem.Thumbnail
+        <Link
           key={reaction.memberProfile.memberId}
-          name={reaction.memberProfile.nickname}
-          // TODO : 리팩토링 필요
-          thumbnail={{
-            url: reaction.memberProfile.profileImageUrl,
-            size: 'h36',
-            variant: 'filled',
-          }}
-        />
+          href={
+            myId === reaction.memberProfile.memberId
+              ? ROUTER.MYPAGE.HOME
+              : ROUTER.PROFILE.DETAIL(reaction.memberProfile.memberId)
+          }
+        >
+          <OneLineListItem.Thumbnail
+            name={reaction.memberProfile.nickname}
+            // TODO : 리팩토링 필요
+            thumbnail={{
+              url: reaction.memberProfile.profileImageUrl,
+              size: 'h36',
+              variant: 'filled',
+            }}
+          />
+        </Link>
       ))}
     </section>
   );

--- a/src/components/ReactionBar/ReactionBottomSheet.tsx
+++ b/src/components/ReactionBar/ReactionBottomSheet.tsx
@@ -30,19 +30,39 @@ function ReactionBottomSheet(props: Props) {
   const viewReactionList = props.data?.find((item) => item.emojiType === selectedEmoji);
 
   return (
-    <BottomSheet
-      headerElement={<Header rightAction="none" title="응원한 사람" />}
-      isShowing={props.isShowing}
-      onClickOutside={props.onClose}
-      isDraggable
-    >
-      <EmojiList data={props.data} selectedEmoji={selectedEmoji} onSelect={setSelectedEmoji} />
-      <PeopleList data={viewReactionList} />
-    </BottomSheet>
+    <>
+      <BottomSheet
+        headerElement={<Header rightAction="none" title="응원한 사람" />}
+        isShowing={props.isShowing}
+        onClickOutside={props.onClose}
+        isDraggable
+      >
+        <EmojiList data={props.data} selectedEmoji={selectedEmoji} onSelect={setSelectedEmoji} />
+        <PeopleList data={viewReactionList} />
+      </BottomSheet>
+      {props.isShowing && (
+        <div
+          className={backDropCss}
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            props.onClose();
+          }}
+        />
+      )}
+    </>
   );
 }
 
 export default ReactionBottomSheet;
+const backDropCss = css({
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  zIndex: 1,
+});
 
 interface EmojiListProps {
   data?: GetReactionsResponse;

--- a/src/components/SnackBar/SnackBarOverlay.tsx
+++ b/src/components/SnackBar/SnackBarOverlay.tsx
@@ -67,7 +67,7 @@ export const snackBarOverlayCss = cva({
       offset: 'appBar',
       position: 'bottom',
       css: {
-        bottom: `136px`,
+        bottom: `88px`,
       },
     },
     {

--- a/src/constants/eventLog.ts
+++ b/src/constants/eventLog.ts
@@ -27,6 +27,7 @@ export const EVENT_LOG_NAME = {
     CLICK_FOLLOW_PROFILE: 'click/followProfile',
     CLICK_FOLLOW_LIST: 'click/followList',
     CLICK_PLUS_BUTTON: 'click/plusButton',
+    CLICK_MY_MISSION: 'click/myMission',
   },
   SELECT_CATEGORY: {
     CLICK_NEXT_BUTTON: 'click/nextButton',


### PR DESCRIPTION
 
## 🎉 변경 사항
- 리액션 리스트를 Home에서 확인할 수 있도록 하였습니다 (my/follower mission list)
- 리액션 삭제 기능을 추가하였습니다. 
- 리액션이 하나도 없는데, 리액션 바텀시트를 열려고 하면 응원을 해야한다는 snackbar를 띄웠습니다. 
- 리액션 바텀시트의 윗부분을 클릭하면, 뒤에 부분이 눌리는 문제가 있었는데 backdrop을 하나 더 둠으로써 이벤트 버블링을 막았습니다. 
- 피드 부분에 날짜가 잘못들어간 부분을 @윤범과 이야기 해서 수정하였습니다. 