### PR TITLE
[Test] ProgressMission util Test

### DIFF
--- a/src/utils/storage/progressMission.test.ts
+++ b/src/utils/storage/progressMission.test.ts
@@ -1,0 +1,24 @@
+import { STORAGE_KEY } from '@/constants/storage';
+import { setMissionTimeStack, setProgressMissionTime } from '@/utils/storage/progressMission';
+
+const TEST_MISSION_ID = '0';
+test('1 is 1', () => {
+  expect(1).toBe(1);
+});
+
+// setProgressMissionTime test
+test('setProgressMissionTime test', () => {
+  setProgressMissionTime(TEST_MISSION_ID, 1000);
+  expect(localStorage.getItem(STORAGE_KEY.PROGRESS_MISSION.TIME(TEST_MISSION_ID))).toBe('1000');
+});
+
+// setMissionTimeStack
+test('setMissionTimeStack test', () => {
+  const time = new Date().getTime();
+  const timeInfo = { time, status: 'start' };
+
+  setMissionTimeStack(TEST_MISSION_ID, 'start');
+  expect(localStorage.getItem(STORAGE_KEY.PROGRESS_MISSION.TIME_STACK(TEST_MISSION_ID))).toBe(
+    JSON.stringify([timeInfo]),
+  );
+});

--- a/src/utils/storage/progressMission.test.ts
+++ b/src/utils/storage/progressMission.test.ts
@@ -2,9 +2,13 @@ import { STORAGE_KEY } from '@/constants/storage';
 import { setMissionTimeStack, setProgressMissionTime } from '@/utils/storage/progressMission';
 
 const TEST_MISSION_ID = '0';
-test('1 is 1', () => {
-  expect(1).toBe(1);
-});
+
+const mockTime = (time: number) => {
+  const mockDate = new Date(time);
+  const spy = jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
+
+  return spy;
+};
 
 // setProgressMissionTime test
 test('setProgressMissionTime test', () => {
@@ -12,34 +16,53 @@ test('setProgressMissionTime test', () => {
   expect(localStorage.getItem(STORAGE_KEY.PROGRESS_MISSION.TIME(TEST_MISSION_ID))).toBe('1000');
 });
 
-// setMissionTimeStack
-test('setMissionTimeStack test', () => {
-  const time = new Date().getTime();
-  const timeInfo = { time, status: 'start' };
-
-  setMissionTimeStack(TEST_MISSION_ID, 'start');
-  expect(localStorage.getItem(STORAGE_KEY.PROGRESS_MISSION.TIME_STACK(TEST_MISSION_ID))).toBe(
-    JSON.stringify([timeInfo]),
-  );
-});
-
-describe('root', () => {
+describe('setMissionTimeStack 테스팅', () => {
+  // beforeEach를 사용해서, 모든 테스트를 실행하기 전에 localStorage를 초기화합니다.
   beforeEach(() => {
     localStorage.clear();
   });
 
   // start -> stop -> restart -> stop
-  test('setMissionTimeStack test', () => {
+  test('start -> stop -> restart -> stop 상태가 time stack에 차례대로 쌓여야합니다.', () => {
+    type StackType = {
+      time: number;
+      status: 'start' | 'stop' | 'restart';
+    };
+    const stack: StackType[] = [
+      { time: 1, status: 'start' },
+      { time: 2, status: 'stop' },
+      { time: 3, status: 'restart' },
+      { time: 4, status: 'stop' },
+    ];
+
+    stack.forEach((data, idx) => {
+      const spy = mockTime(1466424490000 + idx * 10);
+      setMissionTimeStack(TEST_MISSION_ID, data.status);
+      spy.mockRestore();
+    });
+
+    const timeStack = localStorage.getItem(STORAGE_KEY.PROGRESS_MISSION.TIME_STACK(TEST_MISSION_ID)) || '[]';
+    const timeStackData: StackType[] = JSON.parse(timeStack);
+
+    expect(timeStackData.length).toBe(4);
+
+    timeStackData.forEach((data, idx) => {
+      expect(data.time).toBe(1466424490000 + idx * 10);
+      expect(data.status).toBe(stack[idx].status);
+    });
+  });
+
+  test('새로운 stack이 쌓일 때 storage에 쌓이는 시간이 그 당시의 new Date().getTime()과 같아야합니다.', () => {
+    const spy = mockTime(1466424490000);
     setMissionTimeStack(TEST_MISSION_ID, 'start');
-    setMissionTimeStack(TEST_MISSION_ID, 'stop');
-    setMissionTimeStack(TEST_MISSION_ID, 'restart');
-    setMissionTimeStack(TEST_MISSION_ID, 'stop');
+    spy.mockRestore();
 
     const timeStack = localStorage.getItem(STORAGE_KEY.PROGRESS_MISSION.TIME_STACK(TEST_MISSION_ID)) || '[]';
     const timeStackData = JSON.parse(timeStack);
-    console.log('timeStackData: ', timeStackData);
+    const time = timeStackData[0].time;
 
-    expect(timeStackData.length).toBe(4);
-    expect(timeStackData[0].status).toEqual('start');
+    expect(time).toBe(1466424490000);
   });
+});
+
 });

--- a/src/utils/storage/progressMission.test.ts
+++ b/src/utils/storage/progressMission.test.ts
@@ -1,5 +1,10 @@
 import { STORAGE_KEY } from '@/constants/storage';
-import { setMissionTimeStack, setProgressMissionTime } from '@/utils/storage/progressMission';
+import {
+  getProgressMissionTime,
+  setMissionData,
+  setMissionTimeStack,
+  setProgressMissionTime,
+} from '@/utils/storage/progressMission';
 
 const TEST_MISSION_ID = '0';
 
@@ -65,4 +70,74 @@ describe('setMissionTimeStack 테스팅', () => {
   });
 });
 
+// getProgressMissionTime test
+describe('getProgressMissionTime 테스팅', () => {
+  const MOCK_TIME_BASE = 1466424490000;
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  // 진행중인 미션이 없으면 (미션 데이터가 없으면)
+  test('진행중인 미션이 없으면 0이 반환되어야합니다.', () => {
+    const time = getProgressMissionTime(TEST_MISSION_ID);
+    expect(time).toBe(0);
+
+    setMissionTimeStack(TEST_MISSION_ID, 'start');
+    const time2 = getProgressMissionTime(TEST_MISSION_ID);
+    expect(time2).toBe(0);
+  });
+
+  // 진행중인 미션 데이터와 현재 미션 id와 다르면 0이 반환되어야합니다.
+  test('진행중인 미션 데이터와 현재 미션 id와 다르면 0이 반환되어야합니다.', () => {
+    setMissionData(TEST_MISSION_ID);
+    const time = getProgressMissionTime('1');
+    expect(time).toBe(0);
+  });
+
+  // 오늘 진행 중인 미션이 없으면
+  test('오늘 진행 중인 미션이 없으면 0이 반환되어야합니다.', () => {
+    // storage에 저장된 진행중인 미션이 전날의 미션이라면
+    // 2024년 2월 20일 10시 10분 10초
+    const spy = mockTime(1708307992308);
+    setMissionData(TEST_MISSION_ID);
+    setMissionTimeStack(TEST_MISSION_ID, 'start');
+    spy.mockRestore();
+
+    const missionData = localStorage.getItem(STORAGE_KEY.PROGRESS_MISSION.MISSION);
+    expect(missionData).not.toBe(null);
+
+    const time2 = getProgressMissionTime(TEST_MISSION_ID);
+    expect(time2).toBe(0);
+
+    // 진행중이 미션이 전날의 미션이라면, 전날의 미션 데이터가 삭제되어야합니다.
+    expect(localStorage.getItem(STORAGE_KEY.PROGRESS_MISSION.MISSION)).toBe(null);
+  });
+
+  // return 값은 number형 정수여야합니다.
+  test('return 값은 number형 정수여야합니다.', () => {
+    setMissionTimeStack(TEST_MISSION_ID, 'start');
+    const time = getProgressMissionTime(TEST_MISSION_ID);
+    expect(typeof time).toBe('number');
+    expect(time % 1).toBe(0);
+  });
+
+  // start (0) -> current (10)
+  test('start -> current 상태일 때, 10가 반환되어야합니다.', () => {
+    const spy = mockTime(MOCK_TIME_BASE);
+    setMissionTimeStack(TEST_MISSION_ID, 'start');
+    spy.mockRestore();
+
+    const timeStack = localStorage.getItem(STORAGE_KEY.PROGRESS_MISSION.TIME_STACK(TEST_MISSION_ID)) || '[]';
+
+    const spy2 = mockTime(MOCK_TIME_BASE + 10);
+    const time = getProgressMissionTime(TEST_MISSION_ID);
+    spy2.mockRestore();
+    // expect(time).toBe(10);
+  });
+
+  // start -> stop -> current
+
+  // start -> stop -> restart -> current
+  // start -> stop -> restart -> stop -> current
+  // start -> stop -> restart -> stop -> restart -> current
 });

--- a/src/utils/storage/progressMission.test.ts
+++ b/src/utils/storage/progressMission.test.ts
@@ -21,7 +21,6 @@ test('setProgressMissionTime test', () => {
 });
 
 describe('setMissionTimeStack 테스팅', () => {
-  // beforeEach를 사용해서, 모든 테스트를 실행하기 전에 localStorage를 초기화합니다.
   beforeEach(() => {
     localStorage.clear();
   });
@@ -96,8 +95,6 @@ describe('getProgressMissionTime 테스팅', () => {
   });
 
   test('오늘 진행 중인 미션이 없으면 0이 반환되어야합니다.', () => {
-    // storage에 저장된 진행중인 미션이 전날의 미션이라면
-    // 2024년 2월 20일 10시 10분 10초
     const spy = mockTime(1708307992308);
     setMissionData(TEST_MISSION_ID);
     setMissionTimeStack(TEST_MISSION_ID, 'start');
@@ -109,7 +106,6 @@ describe('getProgressMissionTime 테스팅', () => {
     const time2 = getProgressMissionTime(TEST_MISSION_ID);
     expect(time2).toBe(0);
 
-    // 진행중이 미션이 전날의 미션이라면, 전날의 미션 데이터가 삭제되어야합니다.
     expect(localStorage.getItem(STORAGE_KEY.PROGRESS_MISSION.MISSION)).toBe(null);
   });
 

--- a/src/utils/storage/progressMission.test.ts
+++ b/src/utils/storage/progressMission.test.ts
@@ -15,7 +15,6 @@ const mockTime = (time: number) => {
   return spy;
 };
 
-// setProgressMissionTime test
 test('setProgressMissionTime test', () => {
   setProgressMissionTime(TEST_MISSION_ID, 1000);
   expect(localStorage.getItem(STORAGE_KEY.PROGRESS_MISSION.TIME(TEST_MISSION_ID))).toBe('1000');
@@ -27,7 +26,6 @@ describe('setMissionTimeStack 테스팅', () => {
     localStorage.clear();
   });
 
-  // start -> stop -> restart -> stop
   test('start -> stop -> restart -> stop 상태가 time stack에 차례대로 쌓여야합니다.', () => {
     type StackType = {
       time: number;
@@ -41,7 +39,7 @@ describe('setMissionTimeStack 테스팅', () => {
     ];
 
     stack.forEach((data, idx) => {
-      const spy = mockTime(1466424490000 + idx * 10);
+      const spy = mockTime(1708307992308 + idx * 10);
       setMissionTimeStack(TEST_MISSION_ID, data.status);
       spy.mockRestore();
     });
@@ -52,13 +50,13 @@ describe('setMissionTimeStack 테스팅', () => {
     expect(timeStackData.length).toBe(4);
 
     timeStackData.forEach((data, idx) => {
-      expect(data.time).toBe(1466424490000 + idx * 10);
+      expect(data.time).toBe(1708307992308 + idx * 10);
       expect(data.status).toBe(stack[idx].status);
     });
   });
 
   test('새로운 stack이 쌓일 때 storage에 쌓이는 시간이 그 당시의 new Date().getTime()과 같아야합니다.', () => {
-    const spy = mockTime(1466424490000);
+    const spy = mockTime(1708307992308);
     setMissionTimeStack(TEST_MISSION_ID, 'start');
     spy.mockRestore();
 
@@ -66,18 +64,22 @@ describe('setMissionTimeStack 테스팅', () => {
     const timeStackData = JSON.parse(timeStack);
     const time = timeStackData[0].time;
 
-    expect(time).toBe(1466424490000);
+    expect(time).toBe(1708307992308);
   });
 });
 
-// getProgressMissionTime test
 describe('getProgressMissionTime 테스팅', () => {
-  const MOCK_TIME_BASE = 1466424490000;
+  const MOCK_TIME_BASE = 1708307992308;
+
+  const startMission = (missionId: string) => {
+    setMissionData(missionId);
+    setMissionTimeStack(missionId, 'start');
+  };
+
   beforeEach(() => {
     localStorage.clear();
   });
 
-  // 진행중인 미션이 없으면 (미션 데이터가 없으면)
   test('진행중인 미션이 없으면 0이 반환되어야합니다.', () => {
     const time = getProgressMissionTime(TEST_MISSION_ID);
     expect(time).toBe(0);
@@ -87,14 +89,12 @@ describe('getProgressMissionTime 테스팅', () => {
     expect(time2).toBe(0);
   });
 
-  // 진행중인 미션 데이터와 현재 미션 id와 다르면 0이 반환되어야합니다.
   test('진행중인 미션 데이터와 현재 미션 id와 다르면 0이 반환되어야합니다.', () => {
     setMissionData(TEST_MISSION_ID);
     const time = getProgressMissionTime('1');
     expect(time).toBe(0);
   });
 
-  // 오늘 진행 중인 미션이 없으면
   test('오늘 진행 중인 미션이 없으면 0이 반환되어야합니다.', () => {
     // storage에 저장된 진행중인 미션이 전날의 미션이라면
     // 2024년 2월 20일 10시 10분 10초
@@ -113,7 +113,6 @@ describe('getProgressMissionTime 테스팅', () => {
     expect(localStorage.getItem(STORAGE_KEY.PROGRESS_MISSION.MISSION)).toBe(null);
   });
 
-  // return 값은 number형 정수여야합니다.
   test('return 값은 number형 정수여야합니다.', () => {
     setMissionTimeStack(TEST_MISSION_ID, 'start');
     const time = getProgressMissionTime(TEST_MISSION_ID);
@@ -121,23 +120,136 @@ describe('getProgressMissionTime 테스팅', () => {
     expect(time % 1).toBe(0);
   });
 
-  // start (0) -> current (10)
-  test('start -> current 상태일 때, 10가 반환되어야합니다.', () => {
+  const DEFAULT_MS = 1000;
+  const timerMs = Number(process.env.NEXT_PUBLIC_TIMER_MS ?? DEFAULT_MS);
+
+  test('start -> current 상태일 때, 10s가 반환되어야합니다.', () => {
     const spy = mockTime(MOCK_TIME_BASE);
-    setMissionTimeStack(TEST_MISSION_ID, 'start');
+    startMission(TEST_MISSION_ID);
+    console.log('date: ', new Date());
     spy.mockRestore();
 
-    const timeStack = localStorage.getItem(STORAGE_KEY.PROGRESS_MISSION.TIME_STACK(TEST_MISSION_ID)) || '[]';
+    const continueSeconds = 60;
 
-    const spy2 = mockTime(MOCK_TIME_BASE + 10);
+    const spy2 = mockTime(MOCK_TIME_BASE + continueSeconds * timerMs);
     const time = getProgressMissionTime(TEST_MISSION_ID);
     spy2.mockRestore();
-    // expect(time).toBe(10);
+    expect(time).toBe(continueSeconds);
   });
 
-  // start -> stop -> current
+  test('start(0) -> stop(60s) -> current(100s) 상태일 때, 60s가 반환되어야합니다.', () => {
+    const spy = mockTime(MOCK_TIME_BASE);
+    startMission(TEST_MISSION_ID);
+    spy.mockRestore();
 
-  // start -> stop -> restart -> current
-  // start -> stop -> restart -> stop -> current
-  // start -> stop -> restart -> stop -> restart -> current
+    const continueSeconds = 60;
+
+    const spy2 = mockTime(MOCK_TIME_BASE + continueSeconds * timerMs);
+    setMissionTimeStack(TEST_MISSION_ID, 'stop');
+    spy2.mockRestore();
+
+    const stopSeconds = 40;
+
+    const spy3 = mockTime(MOCK_TIME_BASE + stopSeconds * timerMs);
+    const time = getProgressMissionTime(TEST_MISSION_ID);
+    spy3.mockRestore();
+
+    expect(time).toBe(continueSeconds);
+  });
+
+  test('start(0) -> stop(60s) -> restart(100s) -> current(120s) 상태일 때, 80s가 반환되어야합니다.', () => {
+    const spy = mockTime(MOCK_TIME_BASE);
+    startMission(TEST_MISSION_ID);
+    spy.mockRestore();
+
+    const continueSeconds = 60;
+
+    const spy2 = mockTime(MOCK_TIME_BASE + continueSeconds * timerMs);
+    setMissionTimeStack(TEST_MISSION_ID, 'stop');
+    spy2.mockRestore();
+
+    const stopSeconds = 40;
+
+    const spy3 = mockTime(MOCK_TIME_BASE + stopSeconds * timerMs);
+    setMissionTimeStack(TEST_MISSION_ID, 'restart');
+    spy3.mockRestore();
+
+    const restartSeconds = 20;
+
+    const spy4 = mockTime(MOCK_TIME_BASE + (stopSeconds + restartSeconds) * timerMs);
+    const time = getProgressMissionTime(TEST_MISSION_ID);
+    spy4.mockRestore();
+
+    expect(time).toBe(continueSeconds + restartSeconds);
+  });
+
+  test('start(0) -> stop(60s) -> restart(100s) -> stop(120s) -> current(150s) 상태일 때, 90s가 반환되어야합니다.', () => {
+    const spy = mockTime(MOCK_TIME_BASE);
+    startMission(TEST_MISSION_ID);
+    spy.mockRestore();
+
+    const continueSeconds = 60;
+
+    const spy2 = mockTime(MOCK_TIME_BASE + continueSeconds * timerMs);
+    setMissionTimeStack(TEST_MISSION_ID, 'stop');
+    spy2.mockRestore();
+
+    const stopSeconds = 40;
+
+    const spy3 = mockTime(MOCK_TIME_BASE + stopSeconds * timerMs);
+    setMissionTimeStack(TEST_MISSION_ID, 'restart');
+    spy3.mockRestore();
+
+    const restartSeconds = 20;
+
+    const spy4 = mockTime(MOCK_TIME_BASE + (stopSeconds + restartSeconds) * timerMs);
+    setMissionTimeStack(TEST_MISSION_ID, 'stop');
+    spy4.mockRestore();
+
+    const stopSeconds2 = 30;
+
+    const spy5 = mockTime(MOCK_TIME_BASE + (stopSeconds + restartSeconds + stopSeconds2) * timerMs);
+    const time = getProgressMissionTime(TEST_MISSION_ID);
+    spy5.mockRestore();
+
+    expect(time).toBe(continueSeconds + restartSeconds);
+  });
+
+  test('start(0) -> stop(60s) -> restart(100s) -> stop(120s) -> restart(150s) -> current(200s) 상태일 때, 130s가 반환되어야합니다.', () => {
+    const spy = mockTime(MOCK_TIME_BASE);
+    startMission(TEST_MISSION_ID);
+    spy.mockRestore();
+
+    const continueSeconds = 60;
+
+    const spy2 = mockTime(MOCK_TIME_BASE + continueSeconds * timerMs);
+    setMissionTimeStack(TEST_MISSION_ID, 'stop');
+    spy2.mockRestore();
+
+    const stopSeconds = 40;
+
+    const spy3 = mockTime(MOCK_TIME_BASE + stopSeconds * timerMs);
+    setMissionTimeStack(TEST_MISSION_ID, 'restart');
+    spy3.mockRestore();
+
+    const restartSeconds = 20;
+
+    const spy4 = mockTime(MOCK_TIME_BASE + (stopSeconds + restartSeconds) * timerMs);
+    setMissionTimeStack(TEST_MISSION_ID, 'stop');
+    spy4.mockRestore();
+
+    const stopSeconds2 = 30;
+
+    const spy5 = mockTime(MOCK_TIME_BASE + (stopSeconds + restartSeconds + stopSeconds2) * timerMs);
+    setMissionTimeStack(TEST_MISSION_ID, 'restart');
+    spy5.mockRestore();
+
+    const restartSeconds2 = 50;
+
+    const spy6 = mockTime(MOCK_TIME_BASE + (stopSeconds + restartSeconds + stopSeconds2 + restartSeconds2) * timerMs);
+    const time = getProgressMissionTime(TEST_MISSION_ID);
+    spy6.mockRestore();
+
+    expect(time).toBe(continueSeconds + restartSeconds + restartSeconds2);
+  });
 });

--- a/src/utils/storage/progressMission.test.ts
+++ b/src/utils/storage/progressMission.test.ts
@@ -22,3 +22,24 @@ test('setMissionTimeStack test', () => {
     JSON.stringify([timeInfo]),
   );
 });
+
+describe('root', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  // start -> stop -> restart -> stop
+  test('setMissionTimeStack test', () => {
+    setMissionTimeStack(TEST_MISSION_ID, 'start');
+    setMissionTimeStack(TEST_MISSION_ID, 'stop');
+    setMissionTimeStack(TEST_MISSION_ID, 'restart');
+    setMissionTimeStack(TEST_MISSION_ID, 'stop');
+
+    const timeStack = localStorage.getItem(STORAGE_KEY.PROGRESS_MISSION.TIME_STACK(TEST_MISSION_ID)) || '[]';
+    const timeStackData = JSON.parse(timeStack);
+    console.log('timeStackData: ', timeStackData);
+
+    expect(timeStackData.length).toBe(4);
+    expect(timeStackData[0].status).toEqual('start');
+  });
+});

--- a/src/utils/storage/progressMission.ts
+++ b/src/utils/storage/progressMission.ts
@@ -7,12 +7,14 @@ interface MissionData {
   startTime: string;
 }
 
+// 미션을 "처음" 시작할 때 미션 데이터 (시작 시간, mission ID)를 storage에 저장
 export const setMissionData = (missionId: string) => {
   const startTime = new Date().toISOString();
   const missionInfo: MissionData = { missionId, startTime };
   localStorage.setItem(STORAGE_KEY.PROGRESS_MISSION.MISSION, JSON.stringify(missionInfo));
 };
 
+// 미션 진행 상태 storage에 저장
 export const setMissionTimeStack = (missionId: string, status: 'start' | 'stop' | 'restart') => {
   const time = new Date().getTime();
   const timeInfo = { time, status };
@@ -26,6 +28,7 @@ export const setMissionTimeStack = (missionId: string, status: 'start' | 'stop' 
   );
 };
 
+// 미션 진행 상태 storage에서 삭제
 export const removeProgressMissionData = () => {
   const missionId = getProgressMissionIdToStorage();
   if (!missionId) return;

--- a/src/utils/storage/progressMission.ts
+++ b/src/utils/storage/progressMission.ts
@@ -80,10 +80,10 @@ const DEFAULT_MS = 1000;
 const timerMs: number = Number(process.env.NEXT_PUBLIC_TIMER_MS ?? DEFAULT_MS);
 
 export const getProgressMissionTime = (missionId: string): number => {
-  // 진행중인 미션이 없다면
+  // 진행중인 미션이 없다면, 0 반환
   if (!checkIsProgressMission(missionId)) return 0;
 
-  // 진행중인 미션이 있는 경우
+  // 오늘 진행중인 미션이 있는지 체크, 없다면 0 반환
   if (!checkTodayMission(missionId)) return 0;
 
   const progressTimeMs = getProgressMissionTimeToStack(missionId);

--- a/src/utils/storage/progressMission.ts
+++ b/src/utils/storage/progressMission.ts
@@ -80,10 +80,8 @@ const DEFAULT_MS = 1000;
 const timerMs: number = Number(process.env.NEXT_PUBLIC_TIMER_MS ?? DEFAULT_MS);
 
 export const getProgressMissionTime = (missionId: string): number => {
-  // 진행중인 미션이 없다면, 0 반환
   if (!checkIsProgressMission(missionId)) return 0;
 
-  // 오늘 진행중인 미션이 있는지 체크, 없다면 0 반환
   if (!checkTodayMission(missionId)) return 0;
 
   const progressTimeMs = getProgressMissionTimeToStack(missionId);
@@ -91,7 +89,6 @@ export const getProgressMissionTime = (missionId: string): number => {
 
   if (!progressTime) return 0;
 
-  // 10분 이상 진행된 경우 이벤트 기록
   if (progressTime >= 10 * 60) {
     recordTenMinuteEvent(missionId);
   }


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
- progressMission 이라는 util 함수의 테스트를 진행했어요. 
- 해당 util은 스톱워치 페이지에서 스톱워치의 시간이 백그라운드에서도 흐르는 것처럼 보이기 위해 사용하는 로직이예요. 
- progressMission에 관련된 모든 로직에 대해 테스트 코드 작성을 완료한 것은 아니며, 
- 주요 로직인 mission을 시작할 때 미션의 데이터를 저장하는 것, 그리고 미션 진행 시간을 계산하는 로직만을 우선적으로 테스트해보았습니다. 
<!-- 관련 이슈를 적어주세요 -->
<!-- closed #1-->
 

## 🌄 스크린샷
![스크린샷 2024-02-22 오전 11 07 37](https://github.com/depromeet/10mm-client-web/assets/49177223/2e867f0b-5204-4876-bc3e-f1c2ac20f928)

