### PR TITLE
Feed에 페이지네이션 적용

### DIFF
--- a/src/apis/feed.ts
+++ b/src/apis/feed.ts
@@ -3,33 +3,32 @@ import apiInstance from '@/apis/instance.api';
 import { type FeedBaseType, type FeedItemType } from '@/apis/schema/feed';
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 
-type GetFeedMeResponse = Array<FeedItemType>;
+interface GetFeedListRequest {
+  visibility: FeedVisibilityType;
+  size: number;
+  lastId?: number;
+}
+
+type GetFeedMeResponse = {
+  content: Array<FeedItemType>;
+  last: boolean;
+};
 
 type GetFeedByMemberIdResponse = Array<FeedBaseType>;
 
 export type FeedVisibilityType = 'ALL' | 'FOLLOWER' | 'NONE';
 
 export const FEED_API = {
-  getFeedMe: async (): Promise<GetFeedMeResponse> => {
-    const { data } = await apiInstance.get('/feed/me');
-    return data;
-  },
   getFeed: async (memberId: number): Promise<GetFeedByMemberIdResponse> => {
     const { data } = await apiInstance.get(`/feed/${memberId}`);
     return data;
   },
-  getFeedList: async (visibility: FeedVisibilityType): Promise<GetFeedMeResponse> => {
-    const { data } = await apiInstance.get('/feed', { params: { visibility } });
+  getFeedList: async (request: GetFeedListRequest): Promise<GetFeedMeResponse> => {
+    const { data } = await apiInstance.get('/feed/me', {
+      params: { visibility: request.visibility, size: 10, lastId: 70 },
+    });
     return data;
   },
-};
-
-export const useFeedMe = (options?: UseQueryOptions<GetFeedMeResponse>) => {
-  return useQuery<GetFeedMeResponse>({
-    ...options,
-    queryKey: getQueryKey('feedMe'),
-    queryFn: FEED_API.getFeedMe,
-  });
 };
 
 export const useFeedByMemberId = (memberId: number, options?: UseQueryOptions<GetFeedByMemberIdResponse>) => {
@@ -40,10 +39,10 @@ export const useFeedByMemberId = (memberId: number, options?: UseQueryOptions<Ge
   });
 };
 
-export const useGetFeedList = (visibility: FeedVisibilityType, options?: UseQueryOptions<GetFeedMeResponse>) => {
+export const useGetFeedList = (request: GetFeedListRequest, options?: UseQueryOptions<GetFeedMeResponse>) => {
   return useQuery<GetFeedMeResponse>({
     ...options,
-    queryKey: getQueryKey('feedList', { visibility }),
-    queryFn: () => FEED_API.getFeedList(visibility),
+    queryKey: getQueryKey('feedList', request),
+    queryFn: () => FEED_API.getFeedList(request),
   });
 };

--- a/src/apis/getQueryKey.ts
+++ b/src/apis/getQueryKey.ts
@@ -44,6 +44,8 @@ type QueryList = {
   };
   feedList: {
     visibility: string;
+    size: number;
+    lastId?: number;
   };
 
   // reaction

--- a/src/app/feed/FeedList.tsx
+++ b/src/app/feed/FeedList.tsx
@@ -24,14 +24,7 @@ function FeedList({ activeTab }: Props) {
     if (hasNextPage && !isFetching) fetchNextPage();
   });
 
-  if (!data || isLoading)
-    return (
-      <ul className={feedListCss}>
-        <FeedSkeletonItem />
-        <FeedSkeletonItem />
-        <FeedSkeletonItem />
-      </ul>
-    );
+  if (!data || isLoading) return <FeedListSkeleton />;
 
   if (list?.length === 0) {
     return (
@@ -57,6 +50,16 @@ function FeedList({ activeTab }: Props) {
 }
 
 export default FeedList;
+
+function FeedListSkeleton() {
+  return (
+    <ul className={feedListCss}>
+      <FeedSkeletonItem />
+      <FeedSkeletonItem />
+      <FeedSkeletonItem />
+    </ul>
+  );
+}
 
 const emptyFeedCss = css({
   display: 'flex',

--- a/src/app/feed/FeedList.tsx
+++ b/src/app/feed/FeedList.tsx
@@ -1,28 +1,33 @@
 'use client';
 
-import { type FeedVisibilityType, useGetFeedList } from '@/apis/feed';
+import { type FeedVisibilityType, useInfiniteFeedList } from '@/apis/feed';
 import FeedItem, { FeedSkeletonItem } from '@/app/feed/FeedItem';
 import Empty from '@/components/Empty/Empty';
 import { ROUTER } from '@/constants/router';
 import useIntersect from '@/hooks/useIntersect';
 import { css } from '@styled-system/css';
 
-function FeedList({ tabProps }: { tabProps: { activeTab: FeedVisibilityType } }) {
-  const { data, isLoading } = useGetFeedList({
-    visibility: tabProps.activeTab,
-    size: 10,
+interface Props {
+  activeTab: FeedVisibilityType;
+}
+
+function FeedList({ activeTab }: Props) {
+  const { data, isLoading, hasNextPage, isFetching, fetchNextPage } = useInfiniteFeedList({
+    visibility: activeTab,
+    size: 5,
   });
-  const list = data?.content.filter((feed) => feed.recordImageUrl); // 이미지 없는 경우가 있음. 나중에 리팩토링 + 서버와 이야기, FeedItem에 ErrorBoundary 적용해도 좋을 듯.
+
+  const list = data?.content?.filter((feed) => feed.recordImageUrl); // 이미지 없는 경우가 있음. 나중에 리팩토링 + 서버와 이야기, FeedItem에 ErrorBoundary 적용해도 좋을 듯.
 
   const targetRef = useIntersect(async (entry, observer) => {
-    // observer.unobserve(entry.target); // TODO : 한번만 보여줄 지?
-    console.log('entry: ', entry);
-    // if (hasNextPage && !isFetching) fetchNextPage();
+    observer.unobserve(entry.target); // TODO : 한번만 보여줄 지?
+    if (hasNextPage && !isFetching) fetchNextPage();
   });
 
   if (!data || isLoading)
     return (
       <ul className={feedListCss}>
+        <FeedSkeletonItem />
         <FeedSkeletonItem />
         <FeedSkeletonItem />
       </ul>

--- a/src/app/feed/FeedSection.tsx
+++ b/src/app/feed/FeedSection.tsx
@@ -1,11 +1,9 @@
 'use client';
 
-import { useEffect } from 'react';
-import { type FeedVisibilityType, useGetFeedList } from '@/apis/feed';
+import { type FeedVisibilityType } from '@/apis/feed';
 import FeedList from '@/app/feed/FeedList';
 import Tab from '@/components/Tab/Tab';
 import { useTab } from '@/components/Tab/Tab.hooks';
-import useShowGuide, { GUIDE_KEY } from '@/hooks/useShowGuide';
 import { css } from '@/styled-system/css';
 
 const FEED_TABS: { id: FeedVisibilityType; tabName: string }[] = [
@@ -22,26 +20,26 @@ const FEED_TABS: { id: FeedVisibilityType; tabName: string }[] = [
 function FeedSection() {
   const tabProps = useTab(FEED_TABS, 'FOLLOWER');
 
-  const { data, isLoading } = useGetFeedList(tabProps.activeTab as FeedVisibilityType);
-  const feeds = data?.filter((feed) => feed.recordImageUrl); // 이미지 없는 경우가 있음. 나중에 리팩토링 + 서버와 이야기, FeedItem에 ErrorBoundary 적용해도 좋을 듯.
+  // const { data, isLoading } = useGetFeedList(tabProps.activeTab as FeedVisibilityType);
+  // const feeds = data?.filter((feed) => feed.recordImageUrl); // 이미지 없는 경우가 있음. 나중에 리팩토링 + 서버와 이야기, FeedItem에 ErrorBoundary 적용해도 좋을 듯.
 
-  // NOTE: 초기에 팔로워의 피드가 없는 상태라면, 전체 피드로 변경
-  useEffect(() => {
-    if (!isLoading) {
-      if (feeds?.length === 0) {
-        tabProps.onTabClick(FEED_TABS[0]);
-      }
-    }
-  }, [isLoading]);
+  // // NOTE: 초기에 팔로워의 피드가 없는 상태라면, 전체 피드로 변경
+  // useEffect(() => {
+  //   if (!isLoading) {
+  //     if (feeds?.length === 0) {
+  //       tabProps.onTabClick(FEED_TABS[0]);
+  //     }
+  //   }
+  // }, [isLoading]);
 
-  useShowGuide(GUIDE_KEY.ALL_FEED_OPEN, 'appBar');
+  // useShowGuide(GUIDE_KEY.ALL_FEED_OPEN, 'appBar');
 
   return (
     <div>
       <div className={tabWrapperCss}>
         <Tab {...tabProps} />
       </div>
-      <FeedList data={feeds} />
+      <FeedList />
     </div>
   );
 }

--- a/src/app/feed/FeedSection.tsx
+++ b/src/app/feed/FeedSection.tsx
@@ -4,7 +4,8 @@ import { type FeedVisibilityType } from '@/apis/feed';
 import FeedList from '@/app/feed/FeedList';
 import Tab from '@/components/Tab/Tab';
 import { useTab } from '@/components/Tab/Tab.hooks';
-import { css } from '@/styled-system/css';
+import { css, cx } from '@/styled-system/css';
+import { fixedPositionCss } from '@/styles/position';
 
 const FEED_TABS: { id: FeedVisibilityType; tabName: string }[] = [
   {
@@ -37,9 +38,10 @@ function FeedSection() {
 
   return (
     <div>
-      <div className={tabWrapperCss}>
+      <div className={cx(fixedPositionCss, tabWrapperCss)}>
         <Tab {...tabProps} />
       </div>
+      <div className={blankCss} />
       <FeedList activeTab={tabProps.activeTab as FeedVisibilityType} />
     </div>
   );
@@ -49,4 +51,10 @@ export default FeedSection;
 
 const tabWrapperCss = css({
   padding: '16px 16px 4px 16px',
+  backgroundColor: 'bg.surface2',
+  zIndex: 1,
+});
+
+const blankCss = css({
+  height: '50px',
 });

--- a/src/app/feed/FeedSection.tsx
+++ b/src/app/feed/FeedSection.tsx
@@ -33,13 +33,14 @@ function FeedSection() {
   // }, [isLoading]);
 
   // useShowGuide(GUIDE_KEY.ALL_FEED_OPEN, 'appBar');
+  // TODO : 팔로워 피드 없을 때 전체 피드 유도 가이드
 
   return (
     <div>
       <div className={tabWrapperCss}>
         <Tab {...tabProps} />
       </div>
-      <FeedList />
+      <FeedList activeTab={tabProps.activeTab as FeedVisibilityType} />
     </div>
   );
 }

--- a/src/hooks/useIntersect.ts
+++ b/src/hooks/useIntersect.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+//https://tech.kakaoenterprise.com/149
+interface IntersectionObserverInit {
+  /**
+   * target의 가시성을 확인할 때 사용되는 상위 속성 이름- null 입력 시, 기본값으로 브라우저의 Viewport가 설정됨
+   */
+  root?: Element | Document | null;
+  /**
+   * root에 마진값을 주어 범위를 확장 가능
+   */
+  rootMargin?: string;
+  /**
+   * 콜백이 실행되기 위해 target의 가시성이 얼마나 필요한지 백분율로 표시
+   */
+  threshold?: number | number[];
+}
+
+type IntersectHandler = (entry: IntersectionObserverEntry, observer: IntersectionObserver) => void;
+
+const useIntersect = (onIntersect: IntersectHandler, options?: IntersectionObserverInit) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const callback = useCallback(
+    (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) onIntersect(entry, observer);
+      });
+    },
+    [onIntersect],
+  );
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const observer = new IntersectionObserver(callback, options);
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [ref, options, callback]);
+
+  return ref;
+};
+
+export default useIntersect;

--- a/src/styles/position.ts
+++ b/src/styles/position.ts
@@ -1,0 +1,10 @@
+import { css } from '@/styled-system/css';
+
+export const fixedPositionCss = css({
+  position: 'fixed',
+  marginLeft: 'auto',
+  marginRight: 'auto',
+  left: 0,
+  right: 0,
+  maxWidth: '475px',
+});


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
closed #616 
<!-- 관련 이슈를 적어주세요 -->
<!-- closed #1-->

## 🎉 변경 사항
- useInfiniteQuery 를 이용해 무한 스크롤을 구현하였어요. 
- observer를 사용하는 hook은 공통적으로 사용될 거라고 생각해 hooks 폴더에 위치시켰습니다. 
- 무한스크롤 로직과 꼬이는 일이 있어,  "초기에 팔로워의 피드가 없는 상태라면, 전체 피드로 변경" 하는 기능을 잠시 넣어두었습니다. (중요하지 않은 것이고, 다른 방향으로 개선해보면 좋을 것 같아요
- 

## 📚 참고
- https://oliveyoung.tech/blog/2023-10-04/useInfiniteQuery-scroll/