### PR TITLE
10분뒤에 인증 가능 알림

### DIFF
--- a/src/apis/notifications.ts
+++ b/src/apis/notifications.ts
@@ -17,11 +17,26 @@ const NOTIFICATION_APIS = {
   },
 };
 
+const NOTIFICATION_MISSIONS_APIS = {
+  // POST /notifications/missions/remind - 미션 알림
+  remind: (seconds: number) => {
+    return apiInstance.post('/notifications/missions/remind', { seconds });
+  },
+};
+
 export default NOTIFICATION_APIS;
+export { NOTIFICATION_MISSIONS_APIS };
 
 export const useNotifyUrging = (options?: UseMutationOptions<unknown, unknown, NotifyUrgingRequest>) => {
   return useMutationHandleError({
     mutationFn: NOTIFICATION_APIS.notifyUrging,
+    ...options,
+  });
+};
+
+export const useRemind = (options?: UseMutationOptions<unknown, unknown, number>) => {
+  return useMutationHandleError({
+    mutationFn: NOTIFICATION_MISSIONS_APIS.remind,
     ...options,
   });
 };

--- a/src/app/mission/[id]/stopwatch/ButtonSection.tsx
+++ b/src/app/mission/[id]/stopwatch/ButtonSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { NOTIFICATION_MISSIONS_APIS } from '@/apis/notifications';
 import Button from '@/components/Button/Button';
 import { EVENT_LOG_CATEGORY, EVENT_LOG_NAME } from '@/constants/eventLog';
 import { StopwatchStep } from '@/hooks/mission/stopwatch/useStopwatchStatus';
@@ -35,6 +36,8 @@ function ButtonSection({ missionId }: { missionId: string }) {
     }
     onInitStart();
     eventLogger.logEvent(EVENT_LOG_NAME.STOPWATCH.CLICK_START, EVENT_LOG_CATEGORY.STOPWATCH);
+
+    NOTIFICATION_MISSIONS_APIS.remind(600);
   };
 
   const onStopButtonClick = () => {


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
BG
미션을 시작하고 나서 까먹고 인증을 안한다거나 60분이 넘어가면 무슨무슨 에러가 발생하는 경우가 간헐적으로 있었다
시작 후 10분 뒤에 알림을 주어 인증이 가능하게 끔 유도하자

Task
미션 시작하고 10분 뒤에 알림을 주어 이제부터 미션 인증이 가능하다고 알려준다


## 🎉 변경 사항

- 서버 API 호출
- 기본값 10분 => 600 s
